### PR TITLE
Fix language in index template

### DIFF
--- a/api/themes/screeps-api/layout/index.jade
+++ b/api/themes/screeps-api/layout/index.jade
@@ -1,5 +1,5 @@
 doctype html
-html(lang='ru')
+html(lang='en')
     head
         meta(charset='UTF-8')
         meta(http-equiv='X-UA-Compatible', content='IE=edge')


### PR DESCRIPTION
For some reason it's set to Russian, while the page is English. I'm not sure however if this actually matters because it doesn't seem to appear in output.