### PR TITLE
Fix links that went to old docs paths

### DIFF
--- a/api/source/Creep.md
+++ b/api/source/Creep.md
@@ -1,7 +1,7 @@
 # Creep  
 
 
-Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types: 
+Creeps are your units. Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions. Each creep consists of up to 50 body parts with the following possible types:
 ![](img/bodyparts.png)   
 
 <table class="table gameplay-info">
@@ -16,7 +16,7 @@ Creeps are your units. Creeps can move, harvest energy, construct structures, at
         <td>50</td>
         <td>Decreases fatigue by 2 points per tick.</td>
     </tr>
-    <tr> 
+    <tr>
         <td><code style="color: #ffe56d;">WORK</code></td>
         <td>100</td>
         <td>
@@ -28,7 +28,7 @@ Creeps are your units. Creeps can move, harvest energy, construct structures, at
             <p>Upgrades a controller for 1 energy unit per tick.</p>
         </td>
     </tr>
-    <tr> 
+    <tr>
         <td><code style="color: #777;">CARRY</code></td>
         <td>50</td>
         <td>Can contain up to 50 resource units.</td>
@@ -69,7 +69,7 @@ Creeps are your units. Creeps can move, harvest energy, construct structures, at
     </tbody>
 </table>
 
-{% page inherited/RoomObject.md %} 
+{% page inherited/RoomObject.md %}
 
 
 {% api_property body array %}
@@ -83,7 +83,7 @@ boost : string | undefined
 If the body part is boosted, this property specifies the mineral type which is used for boosting. One of the <code>RESOURCE_*</code> constants. <a href="/minerals.html">Learn more</a>
 ===
 type : string
-One of the body part types constants. 
+One of the body part types constants.
 ===
 hits : number
 The remaining amount of hit points of this body part.
@@ -267,7 +267,7 @@ ERR_NOT_IN_RANGE | The target is too far away.
 ERR_NO_BODYPART | There are not enough <code>CLAIM</code> body parts in this creep’s body.
 {% endapi_return_codes %}
 
- 
+
 
 {% api_method build 'target' A %}
 
@@ -376,7 +376,7 @@ if(target) {
         creep.moveTo(target);
     }
 }
-    
+
 ```
 
 Dismantles any (even hostile) structure returning 50% of the energy spent on its repair. Requires the <code>WORK</code> body part. If the creep has an empty <code>CARRY</code> body part, the energy is put into it; otherwise it is dropped on the ground. The target has to be at adjacent square to the creep.
@@ -495,7 +495,7 @@ A body part type, one of the following body part constants:
 						<li><code>HEAL</code></li>
 						<li><code>TOUGH</code></li>
 					</ul>
-				
+
 {% endapi_method_params %}
 
 
@@ -552,7 +552,7 @@ if(target) {
         creep.moveTo(target);
     }
 }
-    
+
 ```
 
 Heal self or another creep. It will restore the target creep’s damaged body parts function and increase the hits counter. Requires the <code>HEAL</code> body part. The target has to be at adjacent square to the creep.
@@ -605,7 +605,7 @@ One of the following constants:
 						<li><code>LEFT</code></li>
 						<li><code>TOP_LEFT</code></li>
 					</ul>
-				
+
 {% endapi_method_params %}
 
 
@@ -734,7 +734,7 @@ An object containing additional options:
 						<li>
 							<div class="api-arg-title">visualizePathStyle</div>
 							<div class="api-arg-type">object</div>
-							<div class="api-arg-desc">Draw a line along the creep’s path using <a href="/hc/en-us/articles/115000962829-RoomVisual#poly"><code>RoomVisual.poly</code></a>. You can provide either an empty object or custom style parameters. The default style is equivalent to:
+							<div class="api-arg-desc">Draw a line along the creep’s path using <a href="#RoomVisual.poly"><code>RoomVisual.poly</code></a>. You can provide either an empty object or custom style parameters. The default style is equivalent to:
 								<pre class="language-javascript"><code>{
     fill: 'transparent',
     stroke: '#fff',
@@ -746,7 +746,7 @@ An object containing additional options:
 						</li>
 						<li>Any options supported by <a href="#Room.findPath"><code>Room.findPath</code></a> method.</li>
 					</ul>
-				
+
 {% endapi_method_params %}
 
 
@@ -1202,5 +1202,3 @@ ERR_FULL | The creep's carry is full.
 ERR_NOT_IN_RANGE | The target is too far away.
 ERR_INVALID_ARGS | The resource amount or type is incorrect.
 {% endapi_return_codes %}
-
-

--- a/api/source/Game.md
+++ b/api/source/Game.md
@@ -1,6 +1,6 @@
 # Game    
 
-The main global game object containing all the game play information. 
+The main global game object containing all the game play information.
 
 
 {% api_property Game.constructionSites 'object&lt;string, <a href="#ConstructionSite">ConstructionSite</a>&gt;' %}
@@ -19,13 +19,13 @@ An object containing information about your CPU usage with the following propert
 
 {% api_method_params %}
 limit : number
-Your CPU limit depending on your <a href="/hc/en-us/articles/203086021-Territory-control">Global Control Level</a>.
+Your CPU limit depending on your <a href="/control.html#Global-Control-Level">Global Control Level</a>.
 ===
 tickLimit : number
-An amount of available CPU time at the current game tick.<br>It can be higher than <code>Game.cpu.limit</code>. <a href="/hc/en-us/articles/204332302">Learn more</a>
+An amount of available CPU time at the current game tick.<br>It can be higher than <code>Game.cpu.limit</code>. <a href="/cpu-limit.html">Learn more</a>
 ===
 bucket : number
-An amount of unused CPU accumulated in your <a href="/hc/en-us/articles/204332302">bucket</a>.
+An amount of unused CPU accumulated in your <a href="/cpu-limit.html#Bucket">bucket</a>.
 {% endapi_method_params %}
 
 
@@ -55,7 +55,7 @@ A hash containing all your flags with flag names as hash keys.
 
 
 
-Your <a href="/hc/en-us/articles/203086021-Territory-control">Global Control Level</a>, an object with the following properties :
+Your <a href="/control.html#Global-Control-Level">Global Control Level</a>, an object with the following properties :
 
 {% api_method_params %}
 level : number
@@ -127,7 +127,7 @@ A hash containing all your structures with structure id as hash keys.
 console.log(Game.time);
 ```
 
-System game tick counter. It is automatically incremented on every tick. <a href="/hc/en-us/articles/203032752-Understanding-game-loop-time-and-ticks">Learn more</a>
+System game tick counter. It is automatically incremented on every tick. <a href="/game-loop.html">Learn more</a>
 
 
 
@@ -197,7 +197,7 @@ if(Game.spawns['Spawn1'].energy == 0) {
     );
 }
 
-``` 
+```
 
 Send a custom message at your profile email. This way, you can set up notifications to yourself on any occasion within the game. You can schedule up to 20 notifications during one game tick. Not available in the Simulation Room.
 
@@ -208,6 +208,3 @@ Custom text which will be sent in the message. Maximum length is 1000 characters
 groupInterval : number
 If set to 0 (default), the notification will be scheduled immediately. Otherwise, it will be grouped with other notifications and mailed out later using the specified time in minutes.
 {% endapi_method_params %}
-
-
-

--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -1,7 +1,7 @@
 # Room
 
-An object representing the room in which your units and structures are in. 
-It can be used to look around, find paths, etc. Every `RoomObject` in the room contains 
+An object representing the room in which your units and structures are in.
+It can be used to look around, find paths, etc. Every `RoomObject` in the room contains
 its linked `Room` instance in the `room` property.
 
 {% api_property controller '<a href="#StructureController">StructureController</a>' %}
@@ -62,7 +62,7 @@ The Storage structure of this room, if present, otherwise undefined.
 
 
 
-{% api_property terminal '<a href="/hc/en-us/articles/207713399-StructureTerminal">StructureTerminal</a>' %}
+{% api_property terminal '<a href="#StructureTerminal">StructureTerminal</a>' %}
 
 
 
@@ -74,7 +74,7 @@ The Terminal structure of this room, if present, otherwise undefined.
 
 
 
-A <a href="/hc/en-us/articles/115000962829-RoomVisual">RoomVisual</a> object for this room. You can use this object to draw simple shapes (lines, circles, text labels) in the room.
+A <a href="#RoomVisual">RoomVisual</a> object for this room. You can use this object to draw simple shapes (lines, circles, text labels) in the room.
 
 
 
@@ -148,7 +148,7 @@ OK | The operation has been scheduled successfully.
 ERR_INVALID_TARGET | The structure cannot be placed at the specified location.
 ERR_FULL | You have too many construction sites. The maximum number of construction sites per player is 100.
 ERR_INVALID_ARGS | The location is incorrect.
-ERR_RCL_NOT_ENOUGH | Room Controller Level insufficient. <a href="/hc/en-us/articles/203086021-Territory-control">Learn more</a>
+ERR_RCL_NOT_ENOUGH | Room Controller Level insufficient. <a href="/control.html">Learn more</a>
 {% endapi_return_codes %}
 
 
@@ -232,7 +232,7 @@ An object with additional options:
 							<div class="api-arg-desc">The result list will be filtered using the <a href="https://lodash.com/docs#filter">Lodash.filter</a> method.</div>
 						</li>
 					</ul>
-				
+
 {% endapi_method_params %}
 
 
@@ -268,7 +268,7 @@ The room direction constant, one of the following:
 * `FIND_EXIT_RIGHT`
 * `FIND_EXIT_BOTTOM`
 * `FIND_EXIT_LEFT`
-			
+
 Or one of the following error codes:
 {% api_return_codes %}
 ERR_NO_PATH | Path can not be found.
@@ -343,12 +343,12 @@ An object containing additonal pathfinding flags:
     <li>
         <div class="api-arg-title">costCallback</div>
         <div class="api-arg-type">function(string, CostMatrix)</div>
-        <div class="api-arg-desc">You can use this callback to modify a <a href="/hc/en-us/articles/207666355"><code>CostMatrix</code></a> for any room during the search. The callback accepts two arguments, <code>roomName</code> and <code>costMatrix</code>. Use the <code>costMatrix</code> instance to make changes to the positions costs. If you return a new matrix from this callback, it will be used instead of the built-in cached one. This option is only used when the new <a href="#PathFinder"><code>PathFinder</code></a> is enabled.</div>
+        <div class="api-arg-desc">You can use this callback to modify a <a href="#PathFinder-CostMatrix"><code>CostMatrix</code></a> for any room during the search. The callback accepts two arguments, <code>roomName</code> and <code>costMatrix</code>. Use the <code>costMatrix</code> instance to make changes to the positions costs. If you return a new matrix from this callback, it will be used instead of the built-in cached one. This option is only used when the new <a href="#PathFinder"><code>PathFinder</code></a> is enabled.</div>
     </li>
     <li>
         <div class="api-arg-title">ignore</div>
         <div class="api-arg-type">array</div>
-        <div class="api-arg-desc">An array of the room's objects or <a href="#RoomPosition">RoomPosition</a> objects which should be treated as walkable tiles during the search. This option cannot be used when the new <a href="/hc/en-us/articles/207023879"><code>PathFinder</code></a> is enabled (use <code>costCallback</code> option instead).</div>
+        <div class="api-arg-desc">An array of the room's objects or <a href="#RoomPosition">RoomPosition</a> objects which should be treated as walkable tiles during the search. This option cannot be used when the new <a href="#PathFinder"><code>PathFinder</code></a> is enabled (use <code>costCallback</code> option instead).</div>
     </li>
     <li>
         <div class="api-arg-title">avoid</div>
@@ -373,10 +373,10 @@ An object containing additonal pathfinding flags:
     <li>
         <div class="api-arg-title">maxRooms</div>
         <div class="api-arg-type">number</div>
-        <div class="api-arg-desc">The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new <a href="/hc/en-us/articles/207023879"><code>PathFinder</code></a> is enabled.</div>
+        <div class="api-arg-desc">The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new <a href="#PathFinder"><code>PathFinder</code></a> is enabled.</div>
     </li>
 </ul>
-				
+
 {% endapi_method_params %}
 
 
@@ -423,7 +423,7 @@ object or null if it cannot be obtained.
 ```javascript
 const look = creep.room.lookAt(target);
 look.forEach(function(lookObject) {
-    if(lookObject.type == LOOK_CREEPS && 
+    if(lookObject.type == LOOK_CREEPS &&
        lookObject[LOOK_CREEPS].getActiveBodyparts(ATTACK) == 0) {
         creep.moveTo(lookObject.creep);
     }
@@ -486,7 +486,7 @@ Set to true if you want to get the result as a plain array.
 
 ### Return value
 
-If `asArray` is set to false or undefined, the method returns 
+If `asArray` is set to false or undefined, the method returns
 an object with all the objects in the specified area in the following format:
 
 ```javascript-content
@@ -585,7 +585,7 @@ Set to true if you want to get the result as a plain array.
 
 ### Return value
 
-If `asArray` is set to false or undefined, the method returns an object 
+If `asArray` is set to false or undefined, the method returns an object
 with all the objects of the given type in the specified area in the following format:
 
 ```javascript-content
@@ -614,4 +614,3 @@ If `asArray` is set to true, the method returns an array in the following format
 	{x: 6, y: 11, structure: {...}}
 ]
 ```
-

--- a/api/source/RoomPosition.md
+++ b/api/source/RoomPosition.md
@@ -1,7 +1,7 @@
 # RoomPosition
 
-An object representing the specified position in the room. Every `RoomObject` in the room 
-contains `RoomPosition` as the `pos` property. The position object of a custom location 
+An object representing the specified position in the room. Every `RoomObject` in the room
+contains `RoomPosition` as the `pos` property. The position object of a custom location
 can be obtained using the [`Room.getPositionAt`](#Room.getPositionAt) method or using the constructor.
 
 {% api_method constructor 'x, y, roomName' 0 %}
@@ -46,8 +46,8 @@ X position in the room.
 
 
 
-Y position in the room. 
- 
+Y position in the room.
+
 
 {% api_method createConstructionSite 'structureType' A %}
 
@@ -71,7 +71,7 @@ OK | The operation has been scheduled successfully.
 ERR_INVALID_TARGET | The structure cannot be placed at the specified location.
 ERR_FULL | You have too many construction sites. The maximum number of construction sites per player is 100.
 ERR_INVALID_ARGS | The location is incorrect.
-ERR_RCL_NOT_ENOUGH | Room Controller Level insufficient. <a href="/hc/en-us/articles/203086021-Territory-control">Learn more</a>
+ERR_RCL_NOT_ENOUGH | Room Controller Level insufficient. <a href="/control.html">Learn more</a>
 {% endapi_return_codes %}
 
 
@@ -171,7 +171,7 @@ An object containing pathfinding options (see <a href="#Room.findPath">Room.find
 								The default value is determined automatically using heuristics.</div>
 						</li>
 					</ul>
-				
+
 {% endapi_method_params %}
 
 
@@ -227,7 +227,7 @@ An object containing one of the following options:
 							<div class="api-arg-desc">Only the objects which pass the filter using the <a href="https://lodash.com/docs#filter">Lodash.filter</a> method will be used.</div>
 						</li>
 					</ul>
-				
+
 {% endapi_method_params %}
 
 
@@ -285,7 +285,7 @@ creep.move(path[0].direction);
 ```javascript
 let path = creep.pos.findPathTo(target, {maxOps: 200});
 if( !path.length || !target.equalsTo(path[path.length - 1]) ) {
-    path = creep.pos.findPathTo(target, 
+    path = creep.pos.findPathTo(target,
         {maxOps: 1000, ignoreDestructibleStructures: true});
 }
 if( path.length ) {
@@ -467,7 +467,7 @@ A boolean value.
 ```javascript
 const look = Game.flags.Flag1.pos.look();
 look.forEach(function(lookObject) {
-    if(lookObject.type == LOOK_CREEPS && 
+    if(lookObject.type == LOOK_CREEPS &&
        lookObject[LOOK_CREEPS].getActiveBodyparts(ATTACK) == 0) {
         creep.moveTo(lookObject.creep);
     }

--- a/api/source/StructurePowerBank.md
+++ b/api/source/StructurePowerBank.md
@@ -2,9 +2,9 @@
 
 <img src="img/powerBank.png" alt="" align="right" />
 
-Non-player structure. Contains power resource which can be obtained by destroying the structure. 
-Hits the attacker creep back on each attack. Learn more about power 
-from [this article](/hc/en-us/articles/205971132-Power).
+Non-player structure. Contains power resource which can be obtained by destroying the structure.
+Hits the attacker creep back on each attack. Learn more about power
+from [this article](/power.html).
 
 <table class="table gameplay-info">
     <tbody>
@@ -43,5 +43,3 @@ The amount of power containing.
 
 
 The amount of game ticks when this structure will disappear.
-
-

--- a/api/source/StructurePowerSpawn.md
+++ b/api/source/StructurePowerSpawn.md
@@ -2,9 +2,9 @@
 
 <img src="img/powerSpawn.png" alt="" align="right" />
 
-Processes power into your account, and spawns power creeps with special unique powers (in development). 
-Learn more about power from [this article](/hc/en-us/articles/205971132-Power).
-	
+Processes power into your account, and spawns power creeps with special unique powers (in development).
+Learn more about power from [this article](/power.html).
+
 <table class="table gameplay-info">
     <tbody>
     <tr>
@@ -111,7 +111,7 @@ ERR_RCL_NOT_ENOUGH | Room Controller Level insufficient to use this structure.
 
 {% api_method transferEnergy 'target, [amount]' A '{"deprecated": "Please use [`Creep.withdraw`](#Creep.withdraw) instead."}' %}
 
- 
+
 
 Transfer the energy from this structure to a creep. You can transfer resources to your creeps from hostile structures as well.
 
@@ -135,5 +135,3 @@ ERR_INVALID_TARGET | The specified target object is not a creep.
 ERR_FULL | The target creep can not carry the given amount of energy.
 ERR_NOT_IN_RANGE | The target creep is too far away.
 {% endapi_return_codes %}
-
-

--- a/source/contributed/caching-overview.md
+++ b/source/contributed/caching-overview.md
@@ -26,7 +26,7 @@ For these reasons it makes sense to limit what is placed in [Memory](/global-obj
 
 ### Global
 
-The [game loop]('http://support.screeps.com/hc/en-us/articles/204825672-New-main-loop-architecture') architecture allows you to define a "loop" function which gets run each tick. Additionally it allows you to define expensive one-time-run code in the outer scope. This is most commonly used to `require` modules-
+The [game loop](/game-loop.html) architecture allows you to define a "loop" function which gets run each tick. Additionally it allows you to define expensive one-time-run code in the outer scope. This is most commonly used to `require` modules-
 
     // executed on new global
     var mod = require('mod');

--- a/source/debugging.md
+++ b/source/debugging.md
@@ -11,14 +11,14 @@ Each action command returns code `OK` if the execution was successful and one of
 
 	var result = creep.attack(target);
     if(result != OK) {
-        console.log(creep + ' failed to attack the target ' + target + 
+        console.log(creep + ' failed to attack the target ' + target +
                         ' with the code: ' + result);
     }
-    
+
 
 Note that a seemingly successful command may not always be executed (for example, your creep faces an obstacle it did not know about when the script started).
 
-In order to safely test your scripts in a parallel copy of the world, you can use our [Public Test Realm](/hc/en-us/articles/205999532-Public-Test-Realm) server.
+In order to safely test your scripts in a parallel copy of the world, you can use our [Public Test Realm](/ptr.html) server.
 
 ## Debugging in the web version
 


### PR DESCRIPTION
I found a few instances where links went to relative paths for the articles on the old docs site.

I've been through looking for any links to `/hc/...` and checked them.