### PR TITLE
Document the effect of safe mode in creep method error codes

### DIFF
--- a/api/source/Creep.md
+++ b/api/source/Creep.md
@@ -227,7 +227,7 @@ The target object to be attacked.
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep.
+ERR_NOT_OWNER | You are not the owner of this creep, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_INVALID_TARGET | The target is not a valid attackable object.
 ERR_NOT_IN_RANGE | The target is too far away.
@@ -260,7 +260,7 @@ The target controller object.
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep.
+ERR_NOT_OWNER | You are not the owner of this creep, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_INVALID_TARGET | The target is not a valid owned or reserved controller object.
 ERR_NOT_IN_RANGE | The target is too far away.
@@ -392,7 +392,7 @@ The target structure.
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep.
+ERR_NOT_OWNER | You are not the owner of this creep, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_INVALID_TARGET | The target is not a valid creep object.
 ERR_NOT_IN_RANGE | The target is too far away.
@@ -568,7 +568,7 @@ The target creep object.
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep.
+ERR_NOT_OWNER | You are not the owner of this creep, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_INVALID_TARGET | The target is not a valid creep object.
 ERR_NOT_IN_RANGE | The target is too far away.
@@ -853,7 +853,7 @@ The target object to be attacked.
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep.
+ERR_NOT_OWNER | You are not the owner of this creep, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_INVALID_TARGET | The target is not a valid attackable object.
 ERR_NOT_IN_RANGE | The target is too far away.
@@ -894,7 +894,7 @@ The target creep object.
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep.
+ERR_NOT_OWNER | You are not the owner of this creep, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_INVALID_TARGET | The target is not a valid creep object.
 ERR_NOT_IN_RANGE | The target is too far away.
@@ -921,7 +921,7 @@ A ranged attack against all hostile creeps or structures within 3 squares range.
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep.
+ERR_NOT_OWNER | You are not the owner of this creep, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_NO_BODYPART | There are no <code>RANGED_ATTACK</code> body parts in this creep’s body.
 {% endapi_return_codes %}
@@ -1194,7 +1194,7 @@ The amount of resources to be transferred. If omitted, all the available amount 
 One of the following codes:
 {% api_return_codes %}
 OK | The operation has been scheduled successfully.
-ERR_NOT_OWNER | You are not the owner of this creep, or there is a hostile rampart on top of the target.
+ERR_NOT_OWNER | You are not the owner of this creep, or there is a hostile rampart on top of the target, or the creep is in a safe mode room.
 ERR_BUSY | The creep is still being spawned.
 ERR_NOT_ENOUGH_RESOURCES | The target does not have the given amount of resources.
 ERR_INVALID_TARGET | The target is not a valid object which can contain the specified resource.


### PR DESCRIPTION
Add safe mode to the list of reasons `attack`, `rangedAttack`, `rangedMassAttack`, `dismantle`, `heal`, `rangedHeal`, `attackController` and `withdraw` might return `ERR_NOT_OWNER`.