### PR TITLE
Clarify Mineral.density documentation.

### DIFF
--- a/api/source/Mineral.md
+++ b/api/source/Mineral.md
@@ -26,7 +26,7 @@ Learn more about minerals from [this article](/minerals.html).
 
 
 
-The density of this mineral deposit, one of the <code>DENSITY_*</code> constants.
+The density that this mineral deposit will be refilled to once <code>ticksToRegeneration</code> reaches 0. This is one of the <code>DENSITY_*</code> constants.
 
 
 


### PR DESCRIPTION
A reader glancing at the Mineral.density documentation would assume that Mineral.density refers to the amount that the mineral deposit was last refilled to. This clarifies that `density` is the amount of resources it will have next time it regenerates.

https://screeps.com/forum/topic/2107/mineral-regenerating-before-density-change/3