### PR TITLE
Adding Creep.carry missing detail

### DIFF
--- a/api/source/Creep.md
+++ b/api/source/Creep.md
@@ -96,7 +96,7 @@ The remaining amount of hit points of this body part.
 const total = _.sum(creep.carry);
 ```
 
-An object with the creep's cargo contents. Each object key is one of the <code>RESOURCE_*</code> constants, values are resources amounts. Use <a href="https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_sumcollection-iteratee-thisarg"><code>lodash.sum</code></a> to get the total amount of contents:
+An object with the creep's cargo contents. Each object key is one of the <code>RESOURCE_*</code> constants, values are resources amounts. <code>RESOURCE_ENERGY</code> is always defined and equals to 0 when empty, other resources are undefined when empty. You can use <a href="https://github.com/lodash/lodash/blob/3.10.1/doc/README.md#_sumcollection-iteratee-thisarg"><code>lodash.sum</code></a> to get the total amount of contents:
 
 
 


### PR DESCRIPTION
Very minor update to make the Creep.carry docs match reality by mirroring the exact phrasing in use for StructureContainer.store and StructureStorage.store currently.