### PR TITLE
Added 'G' to REACTION_TIME constant

### DIFF
--- a/api/source/constants.md
+++ b/api/source/constants.md
@@ -651,6 +651,7 @@ All the following constant names are available in the global scope:
         OH: 20,
         ZK: 5,
         UL: 5,
+        G: 5,
         UH: 10,
         UH2O: 5,
         XUH2O: 60,


### PR DESCRIPTION
The 'G' constant is missing from the refactor of REACTION_TIME.

This is related to the pull request to add 'G' to the constant in screeps/common
https://github.com/screeps/common/pull/5