### PR TITLE
Clarify notifyWhenAttacked CPU usage (Creep)

### DIFF
--- a/api/source/Creep.md
+++ b/api/source/Creep.md
@@ -769,7 +769,7 @@ else {
 }
 ```
 
-Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
+Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default. The constant CPU cost only applies to this function when changing the notification state even when the function returns `OK`.
 
 {% api_method_params %}
 enabled : boolean


### PR DESCRIPTION
Current documentation seems to indicate that every call to notifyWhenAttacked that returns OK would incur the 0.2 CPU cost. Testing on live server shows that the constant cost is only incurred when changing the value.