### PR TITLE
Clarify notifyWhenAttacked CPU usage (Structure)

### DIFF
--- a/api/source/Structure.md
+++ b/api/source/Structure.md
@@ -71,7 +71,7 @@ A boolean value.
 
 
 
-Toggle auto notification when the structure is under attack. The notification will be sent to your account email. Turned on by default.
+Toggle auto notification when the structure is under attack. The notification will be sent to your account email. Turned on by default. The constant CPU cost only applies to this function when changing the notification state even when the function returns `OK`.
 
 {% api_method_params %}
 enabled : boolean


### PR DESCRIPTION
Current documentation seems to indicate that every call to notifyWhenAttacked that returns OK would incur the 0.2 CPU cost. Testing on live server shows that the constant cost is only incurred when changing the value.