### PR TITLE
Update start screeps server command

### DIFF
--- a/source/contributed/ps_ubuntu.md
+++ b/source/contributed/ps_ubuntu.md
@@ -193,7 +193,7 @@ After=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=/home/screeps/world
-ExecStart=/home/screeps/world/node_modules/screeps/bin/screeps.js start
+ExecStart=/bin/usr/npx screeps start
 User=screeps
 Group=screeps
 


### PR DESCRIPTION
The screeps directory inside of node_modules doesn't exist after a fresh installation following all of these instructions. I've had success using "/bin/usr/npx screeps start" instead.