### PR TITLE
set static images to be protocol-relative

### DIFF
--- a/source/invaders.md
+++ b/source/invaders.md
@@ -15,7 +15,7 @@ Currently, NPC invaders attacks do not generate any e-mail notifications, since 
 
 ## Raids
 
-There is a 10% chance that you will get not only a lone Invader but a whole company of them, from 2 to 5. Each Invader has its own role: melee attacker, ranged attacker, or healer. Ranged attackers are different from melee ones in their behavior: they try to stay at a distance from your creeps. The function of healers is evidently to heal other raid members. Also, some creeps may be boosted with ![](http://static.screeps.com/upload/mineral-icons/UH.png), ![](http://static.screeps.com/upload/mineral-icons/KO.png), ![](http://static.screeps.com/upload/mineral-icons/LO.png), or ![](http://static.screeps.com/upload/mineral-icons/ZH.png).
+There is a 10% chance that you will get not only a lone Invader but a whole company of them, from 2 to 5. Each Invader has its own role: melee attacker, ranged attacker, or healer. Ranged attackers are different from melee ones in their behavior: they try to stay at a distance from your creeps. The function of healers is evidently to heal other raid members. Also, some creeps may be boosted with ![](//static.screeps.com/upload/mineral-icons/UH.png), ![](//static.screeps.com/upload/mineral-icons/KO.png), ![](//static.screeps.com/upload/mineral-icons/LO.png), or ![](//static.screeps.com/upload/mineral-icons/ZH.png).
 
 ## Invader creep types
 

--- a/source/minerals.md
+++ b/source/minerals.md
@@ -114,29 +114,29 @@ Boosting one body part takes 30 mineral compound units and 20 energy units. One 
 <th colspan="5" align="center">Base compounds</th>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/OH.png)hydroxide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/H.png) + ![](http://static.screeps.com/upload/mineral-icons/O.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/OH.png)hydroxide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/H.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
 <td>20</td>
 <td>—</td>
 <td>—</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZK.png)zynthium keanite</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/Z.png) + ![](http://static.screeps.com/upload/mineral-icons/K.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZK.png)zynthium keanite</td>
+<td>![](//static.screeps.com/upload/mineral-icons/Z.png) + ![](//static.screeps.com/upload/mineral-icons/K.png)</td>
 <td>5</td>
 <td>—</td>
 <td>—</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/UL.png)utrium lemergite</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/U.png) + ![](http://static.screeps.com/upload/mineral-icons/L.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UL.png)utrium lemergite</td>
+<td>![](//static.screeps.com/upload/mineral-icons/U.png) + ![](//static.screeps.com/upload/mineral-icons/L.png)</td>
 <td>5</td>
 <td>—</td>
 <td>—</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/G.png)ghodium</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZK.png) + ![](http://static.screeps.com/upload/mineral-icons/UL.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/G.png)ghodium</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZK.png) + ![](//static.screeps.com/upload/mineral-icons/UL.png)</td>
 <td>5</td>
 <td>—</td>
 <td>—</td>
@@ -145,71 +145,71 @@ Boosting one body part takes 30 mineral compound units and 20 energy units. One 
 <th colspan="5" align="center">Tier 1 compounds</th>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/UH.png)utrium hydride</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/U.png) + ![](http://static.screeps.com/upload/mineral-icons/H.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UH.png)utrium hydride</td>
+<td>![](//static.screeps.com/upload/mineral-icons/U.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
 <td>10</td>
 <td>`ATTACK`</td>
 <td>+100% `attack` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/UO.png)utrium oxide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/U.png) + ![](http://static.screeps.com/upload/mineral-icons/O.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UO.png)utrium oxide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/U.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
 <td>10</td>
 <td>`WORK`</td>
 <td>+200% `harvest` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/KH.png)keanium hydride</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/K.png) + ![](http://static.screeps.com/upload/mineral-icons/H.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KH.png)keanium hydride</td>
+<td>![](//static.screeps.com/upload/mineral-icons/K.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
 <td>10</td>
 <td>`CARRY`</td>
 <td>+50 capacity</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/KO.png)keanium oxide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/K.png) + ![](http://static.screeps.com/upload/mineral-icons/O.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KO.png)keanium oxide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/K.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
 <td>10</td>
 <td>`RANGED_ATTACK`</td>
 <td>+100% `rangedAttack` and `rangedMassAttack` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/LH.png)lemergium hydride</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/L.png) + ![](http://static.screeps.com/upload/mineral-icons/H.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LH.png)lemergium hydride</td>
+<td>![](//static.screeps.com/upload/mineral-icons/L.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
 <td>15</td>
 <td>`WORK`</td>
 <td>+50% `repair` and `build` effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/LO.png)lemergium oxide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/L.png) + ![](http://static.screeps.com/upload/mineral-icons/O.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LO.png)lemergium oxide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/L.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
 <td>10</td>
 <td>`HEAL`</td>
 <td>+100% `heal` and `rangedHeal` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZH.png)zynthium hydride</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/Z.png) + ![](http://static.screeps.com/upload/mineral-icons/H.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZH.png)zynthium hydride</td>
+<td>![](//static.screeps.com/upload/mineral-icons/Z.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
 <td>20</td>
 <td>`WORK`</td>
 <td>+100% `dismantle` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZO.png)zynthium oxide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/Z.png) + ![](http://static.screeps.com/upload/mineral-icons/O.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZO.png)zynthium oxide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/Z.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
 <td>10</td>
 <td>`MOVE`</td>
 <td>+100% fatigue decrease speed</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/GH.png)ghodium hydride</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/G.png) + ![](http://static.screeps.com/upload/mineral-icons/H.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GH.png)ghodium hydride</td>
+<td>![](//static.screeps.com/upload/mineral-icons/G.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
 <td>10</td>
 <td>`WORK`</td>
 <td>+50% `upgradeController` effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/GO.png)ghodium oxide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/G.png) + ![](http://static.screeps.com/upload/mineral-icons/O.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GO.png)ghodium oxide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/G.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
 <td>10</td>
 <td>`TOUGH`</td>
 <td>-30% damage taken</td>
@@ -218,71 +218,71 @@ Boosting one body part takes 30 mineral compound units and 20 energy units. One 
 <th colspan="5" align="center">Tier 2 compounds</th>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/UH2O.png)utrium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/UH.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UH2O.png)utrium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>5</td>
 <td>`ATTACK`</td>
 <td>+200% `attack` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/UHO2.png)utrium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/UO.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UHO2.png)utrium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>5</td>
 <td>`WORK`</td>
 <td>+400% `harvest` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/KH2O.png)keanium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/KH.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KH2O.png)keanium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>5</td>
 <td>`CARRY`</td>
 <td>+100 capacity</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/KHO2.png)keanium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/KO.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KHO2.png)keanium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>5</td>
 <td>`RANGED_ATTACK`</td>
 <td>+200% `rangedAttack` and `rangedMassAttack` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/LH2O.png)lemergium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/LH.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LH2O.png)lemergium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>10</td>
 <td>`WORK`</td>
 <td>+80% `repair` and `build` effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/LHO2.png)lemergium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/LO.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LHO2.png)lemergium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>5</td>
 <td>`HEAL`</td>
 <td>+200% `heal` and `rangedHeal` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZH2O.png)zynthium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZH.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZH2O.png)zynthium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>40</td>
 <td>`WORK`</td>
 <td>+200% `dismantle` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZHO2.png)zynthium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZO.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZHO2.png)zynthium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>5</td>
 <td>`MOVE`</td>
 <td>+200% fatigue decrease speed</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/GH2O.png)ghodium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/GH.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GH2O.png)ghodium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>15</td>
 <td>`WORK`</td>
 <td>+80% `upgradeController` effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/GHO2.png)ghodium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/GO.png) + ![](http://static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GHO2.png)ghodium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
 <td>30</td>
 <td>`TOUGH`</td>
 <td>-50% damage taken</td>
@@ -291,71 +291,71 @@ Boosting one body part takes 30 mineral compound units and 20 energy units. One 
 <th colspan="5" align="center">Tier 3 compounds</th>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XUH2O.png)catalyzed utrium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/UH2O.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XUH2O.png)catalyzed utrium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>60</td>
 <td>`ATTACK`</td>
 <td>+300% `attack` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XUHO2.png)catalyzed utrium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/UHO2.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XUHO2.png)catalyzed utrium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/UHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>60</td>
 <td>`WORK`</td>
 <td>+600% `harvest` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XKH2O.png)catalyzed keanium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/KH2O.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XKH2O.png)catalyzed keanium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>60</td>
 <td>`CARRY`</td>
 <td>+150 capacity</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XKHO2.png)catalyzed keanium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/KHO2.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XKHO2.png)catalyzed keanium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/KHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>60</td>
 <td>`RANGED_ATTACK`</td>
 <td>+300% `rangedAttack` and `rangedMassAttack` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XLH2O.png)catalyzed lemergium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/LH2O.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XLH2O.png)catalyzed lemergium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>65</td>
 <td>`WORK`</td>
 <td>+100% `repair` and `build` effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XLHO2.png)catalyzed lemergium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/LHO2.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XLHO2.png)catalyzed lemergium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/LHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>60</td>
 <td>`HEAL`</td>
 <td>+300% `heal` and `rangedHeal` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XZH2O.png)catalyzed zynthium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZH2O.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XZH2O.png)catalyzed zynthium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>160</td>
 <td>`WORK`</td>
 <td>+300% `dismantle` effectiveness</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XZHO2.png)catalyzed zynthium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/ZHO2.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XZHO2.png)catalyzed zynthium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/ZHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>60</td>
 <td>`MOVE`</td>
 <td>+300% fatigue decrease speed</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XGH2O.png)catalyzed ghodium acid</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/GH2O.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XGH2O.png)catalyzed ghodium acid</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>80</td>
 <td>`WORK`</td>
 <td>+100% `upgradeController` effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](http://static.screeps.com/upload/mineral-icons/XGHO2.png)catalyzed ghodium alkalide</td>
-<td>![](http://static.screeps.com/upload/mineral-icons/GHO2.png) + ![](http://static.screeps.com/upload/mineral-icons/X.png)</td>
+<td>![](//static.screeps.com/upload/mineral-icons/XGHO2.png)catalyzed ghodium alkalide</td>
+<td>![](//static.screeps.com/upload/mineral-icons/GHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
 <td>150</td>
 <td>`TOUGH`</td>
 <td>-70% damage taken</td>


### PR DESCRIPTION
Along with an update to the SSL certificate used on AWS, this will remove the alerting that parts of the docs site is insecure.