### PR TITLE
Warning about discontinued apps

### DIFF
--- a/source/third-party.md
+++ b/source/third-party.md
@@ -89,7 +89,7 @@ Screeps runs constantly, and as a player it's not possible to watch everything t
 Pushing code to the server can be done using these plugins to common programs.
 
 *   [grunt-screeps](https://github.com/screeps/grunt-screeps) is written and maintained by the Screeps team. It used to upload code to the screeps server using [Grunt](https://gruntjs.com/).
-*   [gulp-screeps](https://github.com/pcmulder/gulp-screeps) is used to upload code to the screeps server using [Gulp](http://gulpjs.com/). (No longer available).
+*   [gulp-screeps](https://github.com/screepers/gulp-screeps) is used to upload code to the screeps server using [Gulp](http://gulpjs.com/).
 
 
 ## Web Client Extensions

--- a/source/third-party.md
+++ b/source/third-party.md
@@ -44,7 +44,7 @@ The Screeps API is not official and may change at any time. These clients are ma
 
 ## Apps
 
-*   [Screeps Monitor](https://play.google.com/store/apps/details?id=com.danielscholte.screepsmonitor) is an Android app that provides players with account and game statistics, as well as a full messaging client and a market history.
+*   [Screeps Monitor](https://play.google.com/store/apps/details?id=com.danielscholte.screepsmonitor) is an Android app that provides players with account and game statistics, as well as a full messaging client and a market history. (No longer available).
 
 
 ## Backups
@@ -89,7 +89,7 @@ Screeps runs constantly, and as a player it's not possible to watch everything t
 Pushing code to the server can be done using these plugins to common programs.
 
 *   [grunt-screeps](https://github.com/screeps/grunt-screeps) is written and maintained by the Screeps team. It used to upload code to the screeps server using [Grunt](https://gruntjs.com/).
-*   [gulp-screeps](https://github.com/pcmulder/gulp-screeps) is used to upload code to the screeps server using [Gulp](http://gulpjs.com/).
+*   [gulp-screeps](https://github.com/pcmulder/gulp-screeps) is used to upload code to the screeps server using [Gulp](http://gulpjs.com/). (No longer available).
 
 
 ## Web Client Extensions


### PR DESCRIPTION
Screeps Monitor app and gulp-screeps flagged as (No longer available).