### PR TITLE
Lint - fix typo in Room.md

### DIFF
--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -433,7 +433,7 @@ Returns an array of events happened on the previous tick in this room.
 
 {% api_method_params %}
 raw : boolean
-If this parameter is false or undefined, the method returns an object parsed using `JSON.parse` which incurs some CPU cost on the first access (the return value is cached on subsequent calls). If `raw` is truthy, then raw JSON in string format is returned.
+If this parameter is false or undefined, the method returns an object parsed using `JSON.parse` which incurs some CPU cost on the first access (the return value is cached on subsequent calls). If `raw` is true, then raw JSON in string format is returned.
 {% endapi_method_params %}
 
 


### PR DESCRIPTION
Just fix a typo (or strange word) in Room.md. Also may be 'truth', but I think 'true' is better, since it is a JS keyword.
Not a big deal.