### PR TITLE
make wasm example work

### DIFF
--- a/source/modules.md
+++ b/source/modules.md
@@ -92,7 +92,8 @@ imports.env = {
     memoryBase: 0,
     tableBase: 0,
     memory: new WebAssembly.Memory({ initial: 256 }),
-    table: new WebAssembly.Table({ initial: 0, element: 'anyfunc' })    
+    table: new WebAssembly.Table({ initial: 2, element: 'anyfunc' }),
+    abort: _ => { throw new Error('abort');},
 };
 
 const wasmInstance = new WebAssembly.Instance(wasmModule, imports);


### PR DESCRIPTION
for node-8.93 and emcc 1.38.12 I needed to change the import table as above