### PR TITLE
fix(api/Room): document EVENT_TRANSFER

### DIFF
--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -557,6 +557,17 @@ The `data` property is different for each event type according to the following 
             </ul>
         </td>
     </tr>           
+    <tr>
+        <td>`EVENT_TRANSFER`</td>
+        <td>
+            A link performed [`transferEnergy`](https://docs.screeps.com/api/#StructureLink.transferEnergy) or a creep performed [`transfer`](#Creep.transfer) or [`withdraw`](#Creep.withdraw).
+            <ul>
+                <li>`targetId` - the target object ID</li>
+                <li>`resourceType` - the type of resource transfered</li>
+                <li>`amount` - the amount of resource transfered</li>
+            </ul>
+        </td>
+    </tr>
 </table>
 
 {% api_method getPositionAt 'x, y' 1 %}

--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -563,8 +563,8 @@ The `data` property is different for each event type according to the following 
             A link performed [`transferEnergy`](https://docs.screeps.com/api/#StructureLink.transferEnergy) or a creep performed [`transfer`](#Creep.transfer) or [`withdraw`](#Creep.withdraw).
             <ul>
                 <li>`targetId` - the target object ID</li>
-                <li>`resourceType` - the type of resource transfered</li>
-                <li>`amount` - the amount of resource transfered</li>
+                <li>`resourceType` - the type of resource transferred</li>
+                <li>`amount` - the amount of resource transferred</li>
             </ul>
         </td>
     </tr>


### PR DESCRIPTION
Adds documentation for EVENT_TRANSFER type events.

Descriptions of properties inferred from `screeps/engine` code.