### PR TITLE
Update documentation to use neutral language

### DIFF
--- a/source/architecture.md
+++ b/source/architecture.md
@@ -28,7 +28,7 @@ A larger picture of stages processing flow could look like this:
 
 A task queue is created for each stage. The tasks of the first stage are scripts of all active players, while the second stage deals with game world rooms. The queue is stored as a Redis List, each task being processed separately by a separate machine.
 
-A tick begins with forming a list of all active players which are put into queue for processing their game scripts. All run-time servers receive tasks from the queue, request the DB data the player needs, and launch computation of his or her game script, collecting commands for various game objects. After the queue is up, the second stage commences. All active commands are put into queue, and run-time servers start processing commands for objects in each room.
+A tick begins with forming a list of all active players which are put into queue for processing their game scripts. All run-time servers receive tasks from the queue, request the DB data the player needs, and launch computation of their game script, collecting commands for various game objects. After the queue is up, the second stage commences. All active commands are put into queue, and run-time servers start processing commands for objects in each room.
 
 Though different rooms on the processing stage and different players on the calculation stage are handled separately in parallel, the number of parallel processes strictly corresponds to the CPU cores number. One room and one player are processed synchronously by one core which rules out various race conditions.
 

--- a/source/community-servers.md
+++ b/source/community-servers.md
@@ -2,7 +2,7 @@
 title: Community Servers
 ---
 
-Screeps is not only a MMO game with the officially maintained open world, but also an open source project. We released [game server software](https://github.com/screeps/screeps) under open license so that everybody can create his own Screeps world and modify it via flexible mod system down to its core, including unique game mechanics and rules, game objects with custom graphics and behavior. 
+Screeps is not only a MMO game with the officially maintained open world, but also an open source project. We released [game server software](https://github.com/screeps/screeps) under open license so that everybody can create their own Screeps world and modify it via flexible mod system down to its core, including unique game mechanics and rules, game objects with custom graphics and behavior. 
 
 We like such community activity, this is why we display public quality servers on the game login screen in the Community Servers list.
 

--- a/source/contributed/modifying-prototypes.md
+++ b/source/contributed/modifying-prototypes.md
@@ -37,7 +37,7 @@ Creep.prototype.suicide = function() {
     this.say("NO WAY!");
 };
 ```
-The above code overwrites the normal [`creep.suicide()`](http://docs.screeps.com/api/#Creep.suicide) function so that instead of suiciding, the creep will voice his disagreement with the command.
+The above code overwrites the normal [`creep.suicide()`](http://docs.screeps.com/api/#Creep.suicide) function so that instead of suiciding, the creep will voice its disagreement with the command.
 
 ### Storing the original method
 When you overwrite a prototype method you lose access to the original function. In Screeps losing access to a vital function such as [`.move()`](http://docs.screeps.com/api/#Creep.move) could be detrimental. Losing access to vital functions can be avoided by storing the original function in a different property before overwriting it so that it can be used later if needed.

--- a/source/introduction.md
+++ b/source/introduction.md
@@ -3,7 +3,7 @@ title: Introduction
 
 ## What kind of game is Screeps
 
-Screeps is a massive multiplayer online real-time strategy game. Each player can create his or her own colony in a **single persistent world** shared by all the players. Such a colony can mine **resources**, build **units**, conquer **territory**. As you conquer more territory, your influence in the game world grows, as well as your abilities to expand your footprint. However, it requires a lot of effort on your part, since multiple players may aim at the same territory.
+Screeps is a massive multiplayer online real-time strategy game. Each player can create their own colony in a **single persistent world** shared by all the players. Such a colony can mine **resources**, build **units**, conquer **territory**. As you conquer more territory, your influence in the game world grows, as well as your abilities to expand your footprint. However, it requires a lot of effort on your part, since multiple players may aim at the same territory.
 
 Screeps is developed for people with **programming skills**. Unlike some other RTS games, your units in Screeps can react to events without your participation – provided that you have programmed them properly. And, unlike other MMO, you do not have to play Screeps constantly to play well. It is quite enough just to check once in a while to see if everything goes well.
 

--- a/source/simultaneous-actions.md
+++ b/source/simultaneous-actions.md
@@ -1,7 +1,7 @@
 title: Simultaneous execution of creep actions
 ---
 
-The exact methods available to a creep are determined by his parts. You may opt to create an all-in-one creep out of all existing parts, but you won't be able to execute all methods simultaneously. Here are the dependencies:
+The exact methods available to a creep are determined by its parts. You may opt to create an all-in-one creep out of all existing parts, but you won't be able to execute all methods simultaneously. Here are the dependencies:
 
 ![](img/action-priorities.png)
 

--- a/source/start-areas.md
+++ b/source/start-areas.md
@@ -17,7 +17,7 @@ The following rules are in force in these rooms:
 
 Novice Areas have the day counter. After it runs out, the walls disappear, rooms lose the green mark, all the limitations are cancelled, and the sector becomes a regular part of the world. After zones are opened, residents can start outward expansion, but can also face invasion into their sectors. 
 
-The majority of novice sectors are divided into 4x4 room size quarters. Apart from the common outer wall that encircles the entire 10x10 sector, there are also inside walls that intersect these “quarters.” The counters of those walls are lower than the total Novice Area counter. It means that each resident starts out in the game by facing other players only in his own “quarter” first, but after a few days he can meet all the residents of the sector. 
+The majority of novice sectors are divided into 4x4 room size quarters. Apart from the common outer wall that encircles the entire 10x10 sector, there are also inside walls that intersect these “quarters.” The counters of those walls are lower than the total Novice Area counter. It means that each resident starts out in the game by facing other players only in their own “quarter” first, but after a few days they can meet all the residents of the sector. 
 
 ## Respawn Areas
 


### PR DESCRIPTION
This pull request does two things:
- All uses of "he" or "his or hers" where the subject is not explicit have been replaced by "they" or "their" as appropriate
- All references to screeps using pronouns have been changed to "its"

Cases where the text refers to an explicit person (such as "Alice" and "Bob" examples) have been left unmodified.