### PR TITLE
Remove wrong parameter from PowerCreep

### DIFF
--- a/api/source/PowerCreep.md
+++ b/api/source/PowerCreep.md
@@ -116,11 +116,6 @@ if(creep.store[RESOURCE_ENERGY] < creep.store.getCapacity()) {
 
 A [`Store`](#Store) object that contains cargo of this creep.
 
-{% api_method_params %}
-username : string
-The name of the owner user.
-{% endapi_method_params %}
-
 {% api_property powers object %}
 Available powers, an object with power ID as a key, and the following properties:
 


### PR DESCRIPTION
The Store Object does not contain a parameter that is called `username`