### PR TITLE
Change node version to 10.x

### DIFF
--- a/source/contributed/ps_ubuntu.md
+++ b/source/contributed/ps_ubuntu.md
@@ -34,7 +34,7 @@ sudo apt install -y build-essential tcl git
 The main world runs on Node8, but Ubuntu only provides an older version of Node6. Fortunately there is another apt repository we can use to get the most up to date versions.
 
 ```shell
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt install -y nodejs
 ```
 


### PR DESCRIPTION
Fixes the outdated node version suggested in docs per: https://github.com/screeps/screeps/issues/110

See comment: https://github.com/screeps/screeps/issues/110#issuecomment-545210257