### PR TITLE
updated docs: EVENT_BUILD

### DIFF
--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -518,7 +518,10 @@ The `data` property is different for each event type according to the following 
             <ul>
                 <li>`targetId` - the target object ID</li>
                 <li>`amount` - the amount of build progress gained</li>
-                <li>`energySpent` - the energy amount spent on the operation</li></ul>
+                <li>`structureType` - one of the `STRUCTURE_*` constants</li>
+                <li>`x, y` - the coordinates of the target object/li>
+                <li>`y` - one of the `STRUCTURE_*` constants.</li>
+                <li>`incomplete` - true if the building is not finished</li></ul>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Updated Room->getEventLog->EVENT_BUILD
(requires clarification: if two or more creeps build a single building, that is finished, is the incomplete flag set to false to all of them or only one?)