### PR TITLE
Small update to the market docs

### DIFF
--- a/api/source/Market.md
+++ b/api/source/Market.md
@@ -206,7 +206,7 @@ Game.market.createOrder({
 });
 ```
 
-Create a market order in your terminal. You will be charged <code>price\*amount\*0.05</code> credits when the order is placed. The maximum orders count is 300 per player. You can create an order at any time with any amount, it will be automatically activated and deactivated depending on the resource/credits availability.
+Create a market order in your terminal. You will be charged a fee of <code>price\*amount\*0.05</code> credits when the order is placed. The order will remain active for 30 days, after which any remaining market fee will be returned to you. The maximum orders count is 300 per player. You can create an order at any time with any amount, it will be automatically activated and deactivated depending on the resource/credits availability.
 
 {% api_method_params %}
 params : object

--- a/api/source/Market.md
+++ b/api/source/Market.md
@@ -220,7 +220,7 @@ An object with the following params:
     <li>
         <div class="api-arg-title">resourceType</div>
         <div class="api-arg-type">string</div>
-        <div class="api-arg-desc">Either one of the <code>RESOURCE_*</code> constants or <code>SUBSCRIPTION_TOKEN</code>. If your Terminal doesn't have the specified resource, the order will be temporary inactive.</div>
+        <div class="api-arg-desc">Either one of the <code>RESOURCE_*</code> constants, <code>CPU_UNLOCK</code>,<code>PIXEL</code> or <code>ACCESS_KEY</code>. If your Terminal doesn't have the specified resource, the order will be temporary inactive.</div>
     </li>
     <li>
         <div class="api-arg-title">price</div>
@@ -235,7 +235,7 @@ An object with the following params:
     <li>
         <div class="api-arg-title">roomName (optional)</div>
         <div class="api-arg-type">string</div>
-        <div class="api-arg-desc">The room where your order will be created. You must have your own Terminal structure in this room, otherwise the created order will be temporary inactive. This argument is not used when <code>resourceType</code> equals to <code>SUBSCRIPTION_TOKEN</code>.</div>
+        <div class="api-arg-desc">The room where your order will be created. You must have your own Terminal structure in this room, otherwise the created order will be temporary inactive. This argument is not used when <code>resourceType</code> is equals <code>CPU_UNLOCK</code>,<code>PIXEL</code> or <code>ACCESS_KEY</code>.</div>
     </li>        
 </ul>
 {% endapi_method_params %}


### PR DESCRIPTION
SUBSCRIPTION_TOKEN -> PIXEL, CPU_UNLOCK & ACCESS_KEY.

One sentences about the 30 day timeout and fee refund on market orders.