### PR TITLE
fix: Room.findPath default plainCost (2) and swampCost (10)

### DIFF
--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -411,12 +411,12 @@ An object containing additonal pathfinding flags:
     <li>
         <div class="api-arg-title">plainCost</div>
         <div class="api-arg-type">number</div>
-        <div class="api-arg-desc">Cost for walking on plain positions. The default is 1.</div>
+        <div class="api-arg-desc">Cost for walking on plain positions. The default is 2.</div>
     </li>
     <li>
         <div class="api-arg-title">swampCost</div>
         <div class="api-arg-type">number</div>
-        <div class="api-arg-desc">Cost for walking on swamp positions. The default is 5.</div>
+        <div class="api-arg-desc">Cost for walking on swamp positions. The default is 10.</div>
     </li>
 </ul>
 


### PR DESCRIPTION
Since the `ignoreRoads` option is false by default, this means the default `plainCost` is 2 and `swampCost` is 10, rather than 1 and 5 respectively.
* [screeps/engine/src/game/rooms.js#L257-L260](https://github.com/screeps/engine/blob/master/src/game/rooms.js#L257-L260)

This makes the default behavior of the following methods to prefer pathing on roads (if roads are available)
* `Room.findPath`, `RoomPosition.findPathTo`, `RoomPosition.findClosestByPath`, `Creep.moveTo`

