### PR TITLE
use `creep.store` instead of deprecated `creep.carry`

### DIFF
--- a/api/source/Creep.md
+++ b/api/source/Creep.md
@@ -411,7 +411,7 @@ creep.drop(RESOURCE_ENERGY);
 
 ```javascript
 // drop all resources
-for(const resourceType in creep.carry) {
+for(const resourceType in creep.store) {
 	creep.drop(resourceType);
 }
 ```
@@ -1152,7 +1152,7 @@ if(creep.transfer(storage, RESOURCE_ENERGY) == ERR_NOT_IN_RANGE) {
 
 ```javascript
 // transfer all resources
-for(const resourceType in creep.carry) {
+for(const resourceType in creep.store) {
 	creep.transfer(storage, resourceType);
 }
 ```

--- a/api/source/PowerCreep.md
+++ b/api/source/PowerCreep.md
@@ -214,7 +214,7 @@ creep.drop(RESOURCE_ENERGY);
 
 ```javascript
 // drop all resources
-for(const resourceType in creep.carry) {
+for(const resourceType in creep.store) {
 	creep.drop(resourceType);
 }
 ```
@@ -665,7 +665,7 @@ if(creep.transfer(storage, RESOURCE_ENERGY) == ERR_NOT_IN_RANGE) {
 
 ```javascript
 // transfer all resources
-for(const resourceType in creep.carry) {
+for(const resourceType in creep.store) {
 	creep.transfer(storage, resourceType);
 }
 ```


### PR DESCRIPTION
Changes the use of the deprecated `creep.carry` calls in the example API documentation code to `creep.store`.