### PR TITLE
StructureLab.mineralType can be undefined

### DIFF
--- a/api/source/StructureLab.md
+++ b/api/source/StructureLab.md
@@ -89,7 +89,7 @@ An alias for [`lab.store[lab.mineralType]`](#StructureExtension.store).
 
 
 
-The type of minerals containing in the lab. Labs can contain only one mineral type at the same time.
+The type of minerals containing in the lab, or undefined. Labs can contain only one mineral type at the same time.
 
 
 


### PR DESCRIPTION
Add information about `undefined` value.
The same as for `StructureController.safeMode`: `How many ticks of safe mode remaining, or undefined.`