### PR TITLE
Build event type was out of date

### DIFF
--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -522,7 +522,8 @@ The `data` property is different for each event type according to the following 
             <ul>
                 <li>`targetId` - the target object ID</li>
                 <li>`amount` - the amount of build progress gained</li>
-                <li>`energySpent` - the energy amount spent on the operation</li></ul>
+                <li>`incomplete` - boolean indicating if the constructionsite is now completed</li></ul>
+		<li>`structureType` - a STRUCTURE_* constant indicating the type of structure</li></ul>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
included energySpent, which the game currently does not populate, and was missing `incomplete` and `structureType` which the game does include/