### PR TITLE
Slack -> Discord

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -24,7 +24,7 @@ The unofficial Chinese version of this documentation translated and maintained b
 
 ## Other resources
 
-* The quickest way to get an answer is asking a question on our [Slack channel](http://chat.screeps.com).
+* The quickest way to get an answer is asking a question on our [Discord channel](http://chat.screeps.com).
 * You can find real working samples for various scenarios from other players at [GitHub](https://github.com/search?o=desc&p=1&q=screeps&s=updated&type=Repositories).
 * If you still have any questions or concerns, please feel free to [submit a request](http://support.screeps.com/hc/en-us/requests/new) or reach out to us by email at [contact@screeps.com](mailto:contact.screeps.com).
 * We also have [forum](http://support.screeps.com/hc/communities/public/topics), [Twitter](https://twitter.com/ScreepsGame), and [Facebook](https://facebook.com/ScreepsGame).


### PR DESCRIPTION
The link still currently reads Slack after the migration to Discord.