### PR TITLE
mineral: ticksToRegeneration can be undefined

### DIFF
--- a/api/source/Mineral.md
+++ b/api/source/Mineral.md
@@ -58,6 +58,6 @@ A unique object identificator. You can use <a href="#Game.getObjectById"><code>
 
 
 
-The remaining time after which the deposit will be refilled.
+The remaining time after which the deposit will be refilled. May be undefined if the Mineral was already refilled.
 
 


### PR DESCRIPTION
Found that `ticksToRegeneration` on a Mineral is actually `undefined` when its amount is not 0
![image](https://user-images.githubusercontent.com/5989971/138452090-b101b79b-d487-41af-add9-77f40b845ba4.png)
![image](https://user-images.githubusercontent.com/5989971/138452188-4f72989a-77e8-4289-883a-32dcbb526e14.png)

Prints from my rooms on shard3.
https://screeps.com/a/#!/room/shard3/E12N51
https://screeps.com/a/#!/room/shard3/E13N51