### PR TITLE
Clarify that containers, roads and walls are unowned structures

### DIFF
--- a/api/source/StructureContainer.md
+++ b/api/source/StructureContainer.md
@@ -4,6 +4,8 @@
 
 A small container that can be used to store resources. This is a walkable structure. All dropped resources automatically goes to the container at the same tile.
 
+This structure is unowned, so it won't be returned in a `room.find(FIND_MY_STRUCTURES)` call.
+
 <table class="table gameplay-info">
     <tbody>
     <tr>

--- a/api/source/StructureRoad.md
+++ b/api/source/StructureRoad.md
@@ -4,6 +4,8 @@
 
 Decreases movement cost to 1. Using roads allows creating creeps with less `MOVE` body parts. You can also build roads on top of natural terrain walls which are otherwise impassable.
 
+This structure is unowned, so it won't be returned in a `room.find(FIND_MY_STRUCTURES)` call.
+
 <table class="table gameplay-info">
     <tbody>
     <tr>

--- a/api/source/StructureWall.md
+++ b/api/source/StructureWall.md
@@ -3,8 +3,11 @@
 <img src="img/wall.png" alt="" align="right" />
 
 Blocks movement of all creeps.
+
 Players can build destructible walls in controlled rooms.
 Some rooms also contain indestructible walls separating novice and respawn areas from the rest of the world or dividing novice / respawn areas into smaller sections. Indestructible walls have no `hits` property.
+
+This structure is unowned, so it won't be returned in a `room.find(FIND_MY_STRUCTURES)` call.
 	
 <table class="table gameplay-info">
     <tbody>


### PR DESCRIPTION
An alternative could be to make a "fake" OwnedStructure page and drop the owned-related properties there instead.