### PR TITLE
Replace `Room.findPath` `opts.heuristicWeight` explanation with version from `PathFinder` `opts` to resolve markdown italics mistake

### DIFF
--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -394,7 +394,7 @@ An object containing additonal pathfinding flags:
     <li>
         <div class="api-arg-title">heuristicWeight</div>
         <div class="api-arg-type">number</div>
-        <div class="api-arg-desc">Weight to apply to the heuristic in the A* formula <code>F = G + weight * H</code>. Use this option only if you understand the underlying A* algorithm mechanics! The default value is 1.2.</div>
+        <div class="api-arg-desc">Weight to apply to the heuristic in the A\* formula <code>F = G + weight \* H</code>. Use this option only if you understand the underlying A\* algorithm mechanics! The default value is 1.2.</div>
     </li>
     <li>
         <div class="api-arg-title">serialize</div>


### PR DESCRIPTION
Currently `Room.findPath` `opts.heuristicWeight` has some unescaped asterisks that produce italic text instead of being readable.

Corrected version copied from https://github.com/screeps/docs/blob/f96f46242d431cd84ae06f6ac70cbba31190050f/api/source/PathFinder.md#L125

I also searched for any other instances of this and didn't find any; all the other un-escaped asterisks are in contexts that don't require escaping (e.g. code blocks).