### PR TITLE
Describe the deprecated nature of renewCreep w.r.t boost removal

### DIFF
--- a/api/source/StructureSpawn.md
+++ b/api/source/StructureSpawn.md
@@ -343,7 +343,7 @@ Energy required for each execution is determined using this formula:
 ceil(creep_cost/2.5/body_size)
 ```
 
-Renewing a creep removes all of its boosts.
+Renewing a creep removes all of its boosts, though this behavior is deprecated and will turn into an error soon.
 
 {% api_method_params %}
 target : <a href="#Creep">Creep</a>


### PR DESCRIPTION
Using renew on a boosted creep results in a [deprecated message](https://github.com/screeps/engine/blob/058d496a13a1eb52b892c09095b69cc8ed889411/src/game/structures.js#L1262).