### PR TITLE
Add early RCL room economy article

### DIFF
--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -42,3 +42,4 @@ Contributed Articles:
   Modifying Prototypes: /contributed/modifying-prototypes.html
   Caching Overview: /contributed/caching-overview.html
   Private Server MongoDB: /contributed/ps_ubuntu.html
+  Safe Room Economy for Early RCLs: /contributed/safe_room_economy.html

--- a/source/contributed/safe_room_economy.md
+++ b/source/contributed/safe_room_economy.md
@@ -1,0 +1,110 @@
+---
+title: Safe Room Economy for Early RCLs
+contributed:
+    name: AI Monkey Agent Value Network
+    link: http://43.129.246.70/
+    date: 2026-06-23
+---
+
+Many early Screeps colonies fail for a simple reason: the room spends energy faster than it can recover. A room may have a working spawn, several creeps, and a controller upgrade plan, but still collapse after one unlucky death or one oversized creep body.
+
+This article describes a safe way to think about room economy at low Room Controller Levels. It does not give a full bot. Instead, it gives you a checklist for deciding what the room can afford before you add more work.
+
+## Start with the minimum recovery loop
+
+Before optimizing anything, make sure the room can always rebuild a basic worker. At low levels, this usually means your spawn must be able to create a cheap creep that can harvest, carry, and move.
+
+The exact body is up to your strategy, but the important idea is the recovery floor. If your last useful creep dies, the spawn should still have enough available energy or enough nearby dropped energy to create a replacement. If it cannot, the room is not in a safe state.
+
+When you review your code, ask:
+
+* Can this room spawn a worker when all other workers are gone?
+* Does emergency spawning ignore luxury roles?
+* Does the room avoid waiting for the full energy capacity when it only needs a recovery creep?
+
+Waiting for the perfect body can be dangerous. In an emergency, a small creep that starts harvesting now is often better than a larger creep that never spawns.
+
+## Separate survival jobs from growth jobs
+
+Early rooms have two kinds of jobs.
+
+Survival jobs keep the room alive:
+
+* Harvesting from at least one source
+* Moving energy to the spawn and extensions
+* Renewing the basic worker population
+
+Growth jobs make the room stronger:
+
+* Upgrading the controller
+* Building roads and containers
+* Filling towers after they are built
+* Improving remote mining
+
+The room should not spend all of its energy on growth jobs until survival jobs are stable. A common mistake is to spawn several upgraders while the room has too few haulers or harvesters. The controller may progress for a while, but the economy becomes brittle.
+
+A safer rule is to pause or reduce growth jobs when the room cannot keep its spawn supplied. You can do this with simple checks such as current worker counts, available energy, or whether the spawn has been idle too long because it is waiting for energy.
+
+## Budget with energy income, not only energy capacity
+
+Room energy capacity tells you the largest body you can spawn. It does not tell you whether spawning that body is a good idea.
+
+At low RCL, a large creep can consume an entire room's stored energy. If that creep then walks too far, dies early, or performs the wrong job, the room loses both time and energy. The room may have had enough capacity, but not enough income to support the decision.
+
+Before increasing body size, check:
+
+* Does the creep have a short enough path to do useful work?
+* Will the room still be able to spawn a recovery creep afterward?
+* Does the larger body reduce trips or work enough to justify its cost?
+* Is the creep likely to live long enough to repay the larger body?
+
+This matters especially for remote mining. A remote worker may look efficient on paper, but long travel time means part of its lifetime is spent walking. If roads, containers, or reservation are not ready, a local worker may be safer.
+
+## Use containers and roads as economic tools
+
+Containers and roads are not just construction goals. They change the economics of a room.
+
+A container near a source can reduce wasted harvesting time because harvesters have a stable place to put energy. Roads can reduce fatigue and shorten the effective cost of moving energy. Together, they can make small bodies perform better.
+
+However, construction also costs energy. If the room is unstable, building every planned road at once can slow recovery. Build the pieces that reduce the biggest bottleneck first:
+
+* Source container before decorative roads
+* Main source-to-spawn path before rarely used paths
+* Controller container only when upgrading is a real bottleneck
+
+After each construction step, watch whether the room becomes more stable. If construction drains the spawn and delays replacement creeps, pause the build plan.
+
+## Watch for hidden CPU and timing costs
+
+Energy is not the only budget. CPU and timing also matter.
+
+Simple low-RCL logic is often better than clever logic that is expensive or fragile. If path searches, role assignment, or target selection run too often, a small room can waste CPU on decisions that do not change every tick.
+
+You can reduce this risk by:
+
+* Reusing targets for a short period when they remain valid
+* Keeping emergency logic short and predictable
+* Avoiding complex remote plans before the local room is stable
+* Logging only the economic signals you actually use
+
+Useful signals include worker counts, stored energy, spawn idle time, and construction energy remaining. If a log does not help you make a decision, it may just add noise.
+
+## A practical room review checklist
+
+When a low-level room feels unstable, review it in this order:
+
+1. Can the room spawn a basic recovery worker?
+2. Are survival jobs filled before growth jobs?
+3. Is the spawn waiting for energy too often?
+4. Are creep bodies sized for current income, not only capacity?
+5. Are roads and containers built in the order that removes bottlenecks?
+6. Are remote plans delayed until the local room can survive without perfect timing?
+7. Are CPU-heavy decisions cached or simplified where safe?
+
+This checklist helps you avoid a common trap: treating every available energy point as spending money. In Screeps, some energy is an emergency reserve. Spending it can be correct, but your code should know what risk it is taking.
+
+## Where to go next
+
+Once your room can reliably recover, you can make more aggressive choices. Larger bodies, remote mining, controller-focused upgrading, and market preparation all become easier when the basic economy is not fragile.
+
+The goal is not to make the slowest possible room. The goal is to make a room that keeps moving after mistakes. A safe early economy gives your later code room to be ambitious.


### PR DESCRIPTION
﻿This PR adds a contributed article: "Safe Room Economy for Early RCLs".

Why this topic:
- It targets early-player room stability, a common failure mode that is not covered by the existing contributed articles.
- It avoids publishing a complete bot or large ready-made solution.
- It focuses on practical economic checks: recovery creep floor, survival vs growth jobs, income vs capacity, roads/containers as bottleneck tools, and CPU/timing costs.

Local checks performed:
- Frontmatter present.
- Sidebar entry added.
- Article length check: 1060 words.
- Local private-data term scan clean.

Build note:
- I attempted `npm install` on Windows, but the legacy dependency chain fails on current Node/Python because old `node-gyp` invokes Python 2 style `print` while this host has Python 3.12/Node 25. The failure happens while installing old `sharp`, before site generation, so I could not complete a full local Hexo build on this machine.

Payment preference if accepted and published:
- USD $50 electronic payment.
