### PR TITLE
Use HTML images in invader table

### DIFF
--- a/source/invaders.md
+++ b/source/invaders.md
@@ -37,18 +37,18 @@ There are two sizes of invader creeps:
 </tr>
 <tr>
 <td style="text-align: left;">Melee</td>
-<td style="text-align: center;">![](img/smallMelee.png)</td>
-<td style="text-align: center;">![](img/bigMelee.png)</td>
+<td style="text-align: center;"><img src="img/smallMelee.png"></td>
+<td style="text-align: center;"><img src="img/bigMelee.png"></td>
 </tr>
 <tr>
 <td style="text-align: left;">Ranged</td>
-<td style="text-align: center;">![](img/smallRanged.png)</td>
-<td style="text-align: center;">![](img/bigRanged.png)</td>
+<td style="text-align: center;"><img src="img/smallRanged.png"></td>
+<td style="text-align: center;"><img src="img/bigRanged.png"></td>
 </tr>
 <tr>
 <td style="text-align: left;">Healer</td>
-<td style="text-align: center;">![](img/smallHealer.png)</td>
-<td style="text-align: center;">![](img/bigHealer.png)</td>
+<td style="text-align: center;"><img src="img/smallHealer.png"></td>
+<td style="text-align: center;"><img src="img/bigHealer.png"></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
## What changed

Replace Markdown image syntax inside the raw HTML invader table with equivalent `<img>` elements.

## Why

Markdown inside raw HTML blocks is renderer-specific and is left unparsed by CommonMark-compatible tooling. Keeping the table self-contained HTML makes the source portable while preserving its existing classes, alignment, images, and rendered layout.

## Validation

- `git diff --check`
- `npm ci && npm run generate` using the repository's Node 10 Alpine build environment
- Inspected the generated `public/invaders.html` table and its six image paths