### PR TITLE
Fix contact email link

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -26,5 +26,5 @@ The unofficial Chinese version of this documentation translated and maintained b
 
 * The quickest way to get an answer is asking a question on our [Discord server](http://chat.screeps.com).
 * You can find real working samples for various scenarios from other players at [GitHub](https://github.com/search?o=desc&p=1&q=screeps&s=updated&type=Repositories).
-* If you still have any questions or concerns, please feel free to [submit a request](http://support.screeps.com/hc/en-us/requests/new) or reach out to us by email at [contact@screeps.com](mailto:contact.screeps.com).
+* If you still have any questions or concerns, please feel free to [submit a request](http://support.screeps.com/hc/en-us/requests/new) or reach out to us by email at [contact@screeps.com](mailto:contact@screeps.com).
 * We also have [forum](http://support.screeps.com/hc/communities/public/topics), [Twitter](https://twitter.com/ScreepsGame), and [Facebook](https://facebook.com/ScreepsGame).


### PR DESCRIPTION
## What changed

Correct the home page email link from `mailto:contact.screeps.com` to `mailto:contact@screeps.com`.

## Why

The visible address was correct, but clicking it opened an invalid recipient because the link target used a dot instead of `@`.

## Validation

- `git diff --check`
- Generated the docs with the repository's Node 10 build environment
- Verified `public/index.html` contains `mailto:contact@screeps.com`