### PR TITLE
Fix game loop CPU API references

### DIFF
--- a/source/game-loop.md
+++ b/source/game-loop.md
@@ -17,8 +17,8 @@ In the **end of the tick, **the commands specified in the `main` accumulate in o
 
 ## Additional information
 
-*   Physically, resource intensity of the `main` execution is limited by the available CPU (see [`Game.cpuLimit`](/api/#Game.cpuLimit)) .
-*   The amount of CPU actually used in the current tick is shown by [`Game.getUsedCpu`](/api/#Game.getUsedCpu).
+*   Physically, resource intensity of the `main` execution is limited by the available CPU (see [`Game.cpu.limit`](/api/#Game.cpu.limit)).
+*   The amount of CPU actually used in the current tick is returned by [`Game.cpu.getUsed`](/api/#Game.cpu.getUsed).
 *   The correlation between the game tick counter ([`Game.time`](/api/#Game.time)) and real time depends on overall capacity of servers affected.
 *   All runtime global scope with all the variables between ticks is erased. See more in [this article](/global-objects.html).
 *   A console command is governed by the same rules: execution is made within one tick as though it is added to the end of `main`.


### PR DESCRIPTION
## What changed

Update the game-loop article to use the current `Game.cpu.limit` property and `Game.cpu.getUsed` method.

## Why

The article still referenced the removed `Game.cpuLimit` and `Game.getUsedCpu` APIs, producing two broken links and directing players to obsolete names.

## Validation

- Confirmed both target declarations in `api/source/Cpu.md`
- Generated the docs with the repository's Node 10 build environment
- `git diff --check`