### PR TITLE
Fix broken API fragment links

### DIFF
--- a/api/source/Creep.md
+++ b/api/source/Creep.md
@@ -344,7 +344,7 @@ if(creep.room.controller) {
 
 ```
 
-Claims a neutral controller under your control. Requires the <code>CLAIM</code> body part. The target has to be at adjacent square to the creep. You need to have the corresponding Global Control Level in order to claim a new room. If you don't have enough GCL, consider <a href="#reserveController">reserving</a> this room instead. <a href="/control.html#Global-Control-Level">Learn more</a>
+Claims a neutral controller under your control. Requires the <code>CLAIM</code> body part. The target has to be at adjacent square to the creep. You need to have the corresponding Global Control Level in order to claim a new room. If you don't have enough GCL, consider <a href="#Creep.reserveController">reserving</a> this room instead. <a href="/control.html#Global-Control-Level">Learn more</a>
 
 {% api_method_params %}
 target : <a href="#StructureController">StructureController</a>

--- a/api/source/Market.md
+++ b/api/source/Market.md
@@ -106,7 +106,7 @@ An array of the last 100 outgoing transactions from your terminals with the foll
 
 An object with your active and inactive buy/sell orders on the market.
 See
-<a href="#getAllOrders"><code>getAllOrders</code></a>
+<a href="#Game.market.getAllOrders"><code>getAllOrders</code></a>
 for properties explanation.
 
 
@@ -275,7 +275,7 @@ for(let i=0; i<orders.length; i++) {
 }
 ```
 
-Execute a trade deal from your Terminal in <code>yourRoomName</code> to another player's Terminal using the specified buy/sell order. Your Terminal will be charged energy units of transfer cost regardless of the order resource type. You can use <a href="#calcTransactionCost"><code>Game.market.calcTransactionCost</code></a> method to estimate it. When multiple players try to execute the same deal, the one with the shortest distance takes precedence. You cannot execute more than 10 deals during one tick.
+Execute a trade deal from your Terminal in <code>yourRoomName</code> to another player's Terminal using the specified buy/sell order. Your Terminal will be charged energy units of transfer cost regardless of the order resource type. You can use <a href="#Game.market.calcTransactionCost"><code>Game.market.calcTransactionCost</code></a> method to estimate it. When multiple players try to execute the same deal, the one with the shortest distance takes precedence. You cannot execute more than 10 deals during one tick.
 
 {% api_method_params %}
 orderId : string
@@ -449,5 +449,5 @@ The order ID.
 ### Return value
 
 An object with the order info. See
-<a href="#getAllOrders"><code>getAllOrders</code></a>
+<a href="#Game.market.getAllOrders"><code>getAllOrders</code></a>
 for properties explanation.

--- a/api/source/PowerCreep.md
+++ b/api/source/PowerCreep.md
@@ -338,7 +338,7 @@ Move the creep using the specified predefined path.
 
 {% api_method_params %}
 path : array|string
-A path value as returned from <a href="#Room.findPath"><code>Room.findPath</code></a>, <a href="#RoomPosition.findPathTo"><code>RoomPosition.findPathTo</code></a>, or <a href="#PathFinder.PathFinder-search"><code>PathFinder.search</code></a> methods. Both array form and serialized string form are accepted.
+A path value as returned from <a href="#Room.findPath"><code>Room.findPath</code></a>, <a href="#RoomPosition.findPathTo"><code>RoomPosition.findPathTo</code></a>, or <a href="#PathFinder.search"><code>PathFinder.search</code></a> methods. Both array form and serialized string form are accepted.
 {% endapi_method_params %}
 
 
@@ -800,6 +800,5 @@ ERR_FULL | The creep's carry is full.
 ERR_NOT_IN_RANGE | The target is too far away.
 ERR_INVALID_ARGS | The resourceType is not one of the <code>RESOURCE_*</code> constants, or the amount is incorrect.
 {% endapi_return_codes %}
-
 
 


### PR DESCRIPTION
## What changed

Correct five fragment links to use the IDs generated for their API declarations:

- `PathFinder.search`
- `Game.market.getAllOrders` (two links)
- `Game.market.calcTransactionCost`
- `Creep.reserveController`

## Why

The previous abbreviated or malformed fragments did not match any element in the combined API page, so the links did nothing.

## Validation

- Generated the complete API reference with the repository's Node 10 build environment
- Checked every `href="#..."` in `public/api/index.html`; all now resolve to generated IDs
- `git diff --check`