### PR TITLE
Use HTTPS canonical URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ timezone:
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: http://docs.screeps.com/
+url: https://docs.screeps.com/
 root: /
 permalink: :title/
 

--- a/api/_config.yml
+++ b/api/_config.yml
@@ -11,7 +11,7 @@ timezone:
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: http://docs.screeps.com/api
+url: https://docs.screeps.com/api
 root: /api/
 permalink: :title.html
 permalink_defaults:


### PR DESCRIPTION
## What changed

Change the configured documentation and API site URLs from `http://docs.screeps.com` to `https://docs.screeps.com`.

## Why

Production is served over HTTPS, but generated canonical, Open Graph, sitemap, and absolute API URLs still advertised the redirecting HTTP origin. Canonical metadata should identify the final production origin directly.

## Validation

- Generated both docs and API output with the repository's Node 10 build environment
- Verified the generated docs canonical URL uses HTTPS
- Verified generated absolute API URLs use HTTPS
- `git diff --check`