### PR TITLE
Remove dead translation alternate links

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -77,13 +77,6 @@ hexo.extend.helper.register('header_menu', function(className){
   return result;
 });
 
-hexo.extend.helper.register('canonical_url', function(lang){
-  var path = this.page.canonical_path;
-  if (lang && lang !== 'en') path = lang + '/' + path;
-
-  return this.config.url + '/' + path;
-});
-
 hexo.extend.helper.register('url_for_lang', function(path){
   var lang = this.page.lang;
   var url = this.url_for(path);

--- a/themes/screeps-docs/layout/partial/head.swig
+++ b/themes/screeps-docs/layout/partial/head.swig
@@ -5,12 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Canonical links -->
   <link rel="canonical" href="{{ url }}">
-  <!-- Alternative links -->
-  {% if page.layout == 'page' or page.layout == 'index' %}
-    {% for lang in site.data.languages %}
-      <link rel="alternative" hreflang="{{ loop.key }}" href="{{ canonical_url(loop.key) }}">
-    {% endfor %}
-  {% endif %}
   <!-- Icon -->
   <link rel="apple-touch-icon" sizes="57x57" href="{{ url_for('icon/apple-touch-icon-57x57.png') }}">
   <link rel="apple-touch-icon" sizes="114x114" href="{{ url_for('icon/apple-touch-icon-114x114.png') }}">


### PR DESCRIPTION
## What changed

Stop generating alternate-language `<link>` elements and remove the helper used only to construct them.

## Why

Every page advertised Russian, Korean, Simplified Chinese, and Traditional Chinese alternatives, but those pages are not generated or deployed and return 404. The relation was also emitted as the invalid `alternative` rather than `alternate`. Advertising nonexistent translations is worse than omitting alternate metadata.

## Validation

- Confirmed the advertised production translation URLs return 404
- Generated the docs with the repository's Node 10 build environment
- Verified generated pages contain no alternate-language links or translation paths
- `git diff --check`