### PR TITLE
Remove references to missing site icons

### DIFF
--- a/themes/screeps-docs/layout/partial/head.swig
+++ b/themes/screeps-docs/layout/partial/head.swig
@@ -11,22 +11,6 @@
       <link rel="alternative" hreflang="{{ loop.key }}" href="{{ canonical_url(loop.key) }}">
     {% endfor %}
   {% endif %}
-  <!-- Icon -->
-  <link rel="apple-touch-icon" sizes="57x57" href="{{ url_for('icon/apple-touch-icon-57x57.png') }}">
-  <link rel="apple-touch-icon" sizes="114x114" href="{{ url_for('icon/apple-touch-icon-114x114.png') }}">
-  <link rel="apple-touch-icon" sizes="72x72" href="{{ url_for('icon/apple-touch-icon-72x72.png') }}">
-  <link rel="apple-touch-icon" sizes="144x144" href="{{ url_for('icon/apple-touch-icon-144x144.png') }}">
-  <link rel="apple-touch-icon" sizes="60x60" href="{{ url_for('icon/apple-touch-icon-60x60.png') }}">
-  <link rel="apple-touch-icon" sizes="120x120" href="{{ url_for('icon/apple-touch-icon-120x120.png') }}">
-  <link rel="apple-touch-icon" sizes="76x76" href="{{ url_for('icon/apple-touch-icon-76x76.png') }}">
-  <link rel="apple-touch-icon" sizes="152x152" href="{{ url_for('icon/apple-touch-icon-152x152.png') }}">
-  <link rel="icon" type="image/png" href="{{ url_for('icon/favicon-196x196.png') }}" sizes="196x196">
-  <link rel="icon" type="image/png" href="{{ url_for('icon/favicon-160x160.png') }}" sizes="160x160">
-  <link rel="icon" type="image/png" href="{{ url_for('icon/favicon-96x96.png') }}" sizes="96x96">
-  <link rel="icon" type="image/png" href="{{ url_for('icon/favicon-16x16.png') }}" sizes="16x16">
-  <link rel="icon" type="image/png" href="{{ url_for('icon/favicon-32x32.png') }}" sizes="32x32">
-  <meta name="msapplication-TileColor" content="#2f83cd">
-  <meta name="msapplication-TileImage" content="{{ url_for('icon/mstile-144x144.png') }}">
   <!-- CSS -->
   <!-- build:css build/css/navy.css -->
   <link rel="stylesheet" href="/css/navy.css?1">


### PR DESCRIPTION
## What changed

Remove favicon, Apple touch icon, and Microsoft tile declarations whose referenced files do not exist.

## Why

The template caused every documentation page to request 14 nonexistent `/icon/...` assets. None of those assets has existed in the repository since its initial import, and the production URLs return 404. Removing stale declarations avoids guaranteed failed requests without inventing replacement branding assets.

## Validation

- Confirmed representative favicon, touch icon, and tile URLs return 404 in production
- Generated the docs with the repository's Node 10 build environment
- Verified generated HTML contains no `/icon/` references
- `git diff --check`