### PR TITLE
Replace Markdown inside HTML

### DIFF
--- a/api/source/Deposit.md
+++ b/api/source/Deposit.md
@@ -11,7 +11,7 @@ Learn more about deposits from [this article](/resources.html).
     <tbody>
     <tr>
         <td><strong>Cooldown</strong></td> 
-        <td>`0.001 * totalHarvested ^ 1.2`<td>
+        <td><code>0.001 * totalHarvested ^ 1.2</code><td>
     </tr>
     <tr>
         <td><strong>Decay</strong></td>

--- a/api/source/Map.md
+++ b/api/source/Map.md
@@ -219,7 +219,7 @@ switch(terrain.get(10,15)) {
 }
 ```
 
-Get a <a href="#Room-Terrain">`Room.Terrain`</a> object which provides fast access to static terrain data. This method works for any room in the world even if you have no access to it.
+Get a <a href="#Room-Terrain"><code>Room.Terrain</code></a> object which provides fast access to static terrain data. This method works for any room in the world even if you have no access to it.
 
 {% api_method_params %}
 roomName : string
@@ -229,7 +229,7 @@ The room name.
 
 ### Return value
 
-Returns new <a href="#Room-Terrain">`Room.Terrain`</a> object.
+Returns new <a href="#Room-Terrain"><code>Room.Terrain</code></a> object.
 
 
 {% api_method Game.map.getTerrainAt 'x, y, roomName|pos' 1 '{"deprecated": "Please use a faster method [`Game.map.getRoomTerrain`](#Game.map.getRoomTerrain) instead."}'%}
@@ -318,4 +318,3 @@ property | type | description
 ---|---
 `status` | string | One of the following string values: <ul><li><code>normal</code> &ndash; the room has no restrictions</li><li><code>closed</code> &ndash; the room is not available</li><li><code>novice</code> &ndash; the room is part of a novice area</li><li><code>respawn</code> &ndash; the room is part of a respawn area</li></ul>
 `timestamp` | number | Status expiration time <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime#Syntax">in milliseconds since UNIX epoch time</a>. This property is null if the status is permanent.  
-

--- a/api/source/PathFinder.md
+++ b/api/source/PathFinder.md
@@ -117,7 +117,7 @@ An object containing additional pathfinding flags.
     <li>
         <div class="api-arg-title">maxCost</div>
         <div class="api-arg-type">number</div>
-        <div class="api-arg-desc">The maximum allowed cost of the path returned. If at any point the pathfinder detects that it is impossible to find a path with a cost less than or equal to `maxCost` it will immediately halt the search. The default is Infinity.</div>
+        <div class="api-arg-desc">The maximum allowed cost of the path returned. If at any point the pathfinder detects that it is impossible to find a path with a cost less than or equal to <code>maxCost</code> it will immediately halt the search. The default is Infinity.</div>
     </li>
     <li>
         <div class="api-arg-title">heuristicWeight</div>

--- a/api/source/Room.Terrain.md
+++ b/api/source/Room.Terrain.md
@@ -69,7 +69,7 @@ for(let y = 0; y < 50; y++) {
 }
 ```
 
-Get terrain type at the specified room position by `(x,y)` coordinates. Unlike the <a href="#Game.map.getTerrainAt">`Game.map.getTerrainAt(...)`</a> method, this one doesn't perform any string operations and returns integer terrain type values (see below).
+Get terrain type at the specified room position by `(x,y)` coordinates. Unlike the <a href="#Game.map.getTerrainAt"><code>Game.map.getTerrainAt(...)</code></a> method, this one doesn't perform any string operations and returns integer terrain type values (see below).
 
 {% api_method_params %}
 x : number

--- a/api/source/Room.md
+++ b/api/source/Room.md
@@ -486,134 +486,134 @@ The `data` property is different for each event type according to the following 
         <th>event</th><th>description</th>
     </tr>
     <tr>
-        <td>`EVENT_ATTACK`</td>
+        <td><code>EVENT_ATTACK</code></td>
         <td>
             A creep or a structure performed an attack to another object.
             <ul>
-                <li>`targetId` - the target object ID</li>
-                <li>`damage` - the amount of hits damaged</li>
-                <li>`attackType` - one of the following constants:
+                <li><code>targetId</code> - the target object ID</li>
+                <li><code>damage</code> - the amount of hits damaged</li>
+                <li><code>attackType</code> - one of the following constants:
                     <ul>
-                        <li>`EVENT_ATTACK_TYPE_MELEE` - a creep attacked with [attack](#Creep.attack)</li>
-                        <li>`EVENT_ATTACK_TYPE_RANGED` - a creep attacked with [rangedAttack](#Creep.rangedAttack), or a tower attacked with [attack](#StructureTower.attack)</li> 
-                        <li>`EVENT_ATTACK_TYPE_RANGED_MASS` - a creep attacked with [rangedMassAttack](#Creep.rangedMassAttack)</li>
-                        <li>`EVENT_ATTACK_TYPE_DISMANTLE` - a creep attacked with [dismantle](#Creep.dismantle)</li>
-                        <li>`EVENT_ATTACK_TYPE_HIT_BACK` - a creep hit back on another creep's [attack](#Creep.attack)</li>
-                        <li>`EVENT_ATTACK_TYPE_NUKE` - a nuke landed</li>
+                        <li><code>EVENT_ATTACK_TYPE_MELEE</code> - a creep attacked with <a href="#Creep.attack">attack</a></li>
+                        <li><code>EVENT_ATTACK_TYPE_RANGED</code> - a creep attacked with <a href="#Creep.rangedAttack">rangedAttack</a>, or a tower attacked with <a href="#StructureTower.attack">attack</a></li>
+                        <li><code>EVENT_ATTACK_TYPE_RANGED_MASS</code> - a creep attacked with <a href="#Creep.rangedMassAttack">rangedMassAttack</a></li>
+                        <li><code>EVENT_ATTACK_TYPE_DISMANTLE</code> - a creep attacked with <a href="#Creep.dismantle">dismantle</a></li>
+                        <li><code>EVENT_ATTACK_TYPE_HIT_BACK</code> - a creep hit back on another creep's <a href="#Creep.attack">attack</a></li>
+                        <li><code>EVENT_ATTACK_TYPE_NUKE</code> - a nuke landed</li>
                     </ul>
                 </li>
             </ul>
         </td>
     </tr>
     <tr>
-        <td>`EVENT_OBJECT_DESTROYED`</td>
+        <td><code>EVENT_OBJECT_DESTROYED</code></td>
         <td>
             A game object is destroyed or killed.
-            <ul><li>`type` - the type of the destroyed object</li></ul>
+            <ul><li><code>type</code> - the type of the destroyed object</li></ul>
         </td>
     </tr>
     <tr>
-        <td>`EVENT_ATTACK_CONTROLLER`</td>
-        <td>A creep performed [`attackController`](#Creep.attackController) in the room.</td>
+        <td><code>EVENT_ATTACK_CONTROLLER</code></td>
+        <td>A creep performed <a href="#Creep.attackController"><code>attackController</code></a> in the room.</td>
     </tr>
     <tr>
-        <td>`EVENT_BUILD`</td>
+        <td><code>EVENT_BUILD</code></td>
         <td>
-            A creep performed [`build`](#Creep.build) in the room.
+            A creep performed <a href="#Creep.build"><code>build</code></a> in the room.
             <ul>
-                <li>`targetId` - the target object ID</li>
-                <li>`amount` - the amount of build progress gained</li>
-                <li>`structureType` - one of the STRUCTURE_* constants</li>
-                <li>`x` - the X position of the target construction site</li>
-                <li>`y` - the Y position of the target construction site</li>
-                <li>`incomplete` - status of build progress</li>
+                <li><code>targetId</code> - the target object ID</li>
+                <li><code>amount</code> - the amount of build progress gained</li>
+                <li><code>structureType</code> - one of the STRUCTURE_* constants</li>
+                <li><code>x</code> - the X position of the target construction site</li>
+                <li><code>y</code> - the Y position of the target construction site</li>
+                <li><code>incomplete</code> - status of build progress</li>
 	        </ul>
         </td>
     </tr>
     <tr>
-        <td>`EVENT_HARVEST`</td>
+        <td><code>EVENT_HARVEST</code></td>
         <td>
-            A creep performed [`harvest`](#Creep.harvest) in the room.
+            A creep performed <a href="#Creep.harvest"><code>harvest</code></a> in the room.
             <ul>
-                <li>`targetId` - the target object ID</li>
-                <li>`amount` - the amount of resource harvested</li>
+                <li><code>targetId</code> - the target object ID</li>
+                <li><code>amount</code> - the amount of resource harvested</li>
             </ul>
         </td>
     </tr>
     <tr>
-        <td>`EVENT_HEAL`</td>
+        <td><code>EVENT_HEAL</code></td>
         <td>
             A creep or a tower healed a creep.
             <ul>
-                <li>`targetId` - the target object ID</li>
-                <li>`amount` - the amount of hits healed</li>
-                <li>`healType` - one of the following constants:
+                <li><code>targetId</code> - the target object ID</li>
+                <li><code>amount</code> - the amount of hits healed</li>
+                <li><code>healType</code> - one of the following constants:
                     <ul>
-                        <li>`EVENT_HEAL_TYPE_MELEE` - a creep healed with [heal](#Creep.heal)</li>
-                        <li>`EVENT_HEAL_TYPE_RANGED` - a creep healed with [rangedHeal](#Creep.rangedHeal), or a tower healed with [heal](#StructureTower.heal)</li>
+                        <li><code>EVENT_HEAL_TYPE_MELEE</code> - a creep healed with <a href="#Creep.heal">heal</a></li>
+                        <li><code>EVENT_HEAL_TYPE_RANGED</code> - a creep healed with <a href="#Creep.rangedHeal">rangedHeal</a>, or a tower healed with <a href="#StructureTower.heal">heal</a></li>
                     </ul>
                 </li>
             </ul>
         </td>
     </tr>
     <tr>
-        <td>`EVENT_REPAIR`</td>
+        <td><code>EVENT_REPAIR</code></td>
         <td>
             A creep or a tower repaired a structure.
             <ul>
-                <li>`targetId` - the target object ID</li>
-                <li>`amount` - the amount of hits repaired</li> 
-                <li>`energySpent` - the energy amount spent on the operation</li>
+                <li><code>targetId</code> - the target object ID</li>
+                <li><code>amount</code> - the amount of hits repaired</li>
+                <li><code>energySpent</code> - the energy amount spent on the operation</li>
             </ul>
         </td>
     </tr>        
     <tr>
-        <td>`EVENT_RESERVE_CONTROLLER`</td>
+        <td><code>EVENT_RESERVE_CONTROLLER</code></td>
         <td>
-            A creep performed [`reserveController`](#Creep.reserveController) in the room.
+            A creep performed <a href="#Creep.reserveController"><code>reserveController</code></a> in the room.
             <ul>
-                <li>`amount` - the amount of reservation time gained</li>
+                <li><code>amount</code> - the amount of reservation time gained</li>
             </ul>
         </td>
     </tr> 
     <tr>
-        <td>`EVENT_UPGRADE_CONTROLLER`</td>
+        <td><code>EVENT_UPGRADE_CONTROLLER</code></td>
         <td>
-            A creep performed [`upgradeController`](#Creep.upgradeController) in the room.
+            A creep performed <a href="#Creep.upgradeController"><code>upgradeController</code></a> in the room.
             <ul>
-                <li>`amount` - the amount of control points gained</li> 
-                <li>`energySpent` - the energy amount spent on the operation</li>
+                <li><code>amount</code> - the amount of control points gained</li>
+                <li><code>energySpent</code> - the energy amount spent on the operation</li>
             </ul>
         </td>
     </tr>    
     <tr>
-        <td>`EVENT_EXIT`</td>
+        <td><code>EVENT_EXIT</code></td>
         <td>
             A creep moved to another room.
             <ul>
-                <li>`room` - the name of the target room</li> 
-                <li>`x`, `y` - the coordinates in another room where the creep has appeared</li>
+                <li><code>room</code> - the name of the target room</li>
+                <li><code>x</code>, <code>y</code> - the coordinates in another room where the creep has appeared</li>
             </ul>
         </td>
     </tr>           
     <tr>
-        <td>`EVENT_TRANSFER`</td>
+        <td><code>EVENT_TRANSFER</code></td>
         <td>
-            A link performed [`transferEnergy`](https://docs.screeps.com/api/#StructureLink.transferEnergy) or a creep performed [`transfer`](#Creep.transfer) or [`withdraw`](#Creep.withdraw).
+            A link performed <a href="https://docs.screeps.com/api/#StructureLink.transferEnergy"><code>transferEnergy</code></a> or a creep performed <a href="#Creep.transfer"><code>transfer</code></a> or <a href="#Creep.withdraw"><code>withdraw</code></a>.
             <ul>
-                <li>`targetId` - the target object ID</li>
-                <li>`resourceType` - the type of resource transferred</li>
-                <li>`amount` - the amount of resource transferred</li>
+                <li><code>targetId</code> - the target object ID</li>
+                <li><code>resourceType</code> - the type of resource transferred</li>
+                <li><code>amount</code> - the amount of resource transferred</li>
             </ul>
         </td>
     </tr>
     <tr>
-        <td>`EVENT_POWER`</td>
+        <td><code>EVENT_POWER</code></td>
         <td>
             Apply one the creep's powers on the specified target.
             <ul>
-                <li>`targetId` - the target object ID</li>
-                <li>`power` - the power ability to use, one of the PWR_* constants</li>
+                <li><code>targetId</code> - the target object ID</li>
+                <li><code>power</code> - the power ability to use, one of the PWR_* constants</li>
             </ul>
         </td>
     </tr>
@@ -657,11 +657,11 @@ switch(terrain.get(10,15)) {
 }
 ```
 
-Get a <a href="#Room-Terrain">`Room.Terrain`</a> object which provides fast access to static terrain data. This method works for any room in the world even if you have no access to it.
+Get a <a href="#Room-Terrain"><code>Room.Terrain</code></a> object which provides fast access to static terrain data. This method works for any room in the world even if you have no access to it.
 
 ### Return value
 
-Returns new <a href="#Room-Terrain">`Room.Terrain`</a> object.
+Returns new <a href="#Room-Terrain"><code>Room.Terrain</code></a> object.
 
 {% api_method lookAt 'x, y|target' 2 %}
 

--- a/api/source/StructureLab.md
+++ b/api/source/StructureLab.md
@@ -44,7 +44,7 @@ Learn more about minerals from [this article](/resources.html).
     </tr>
     <tr>
         <td><strong>Reaction cooldown</strong></td>
-        <td>Depends on the reaction (see [this article](/resources.html))</td>
+        <td>Depends on the reaction (see <a href="/resources.html">this article</a>)</td>
     </tr>
     <tr>
         <td><strong>Distance to input labs</strong></td>

--- a/api/source/StructureSpawn.md
+++ b/api/source/StructureSpawn.md
@@ -263,7 +263,7 @@ An object with additional options for the spawning process.
     <li>
         <div class="api-arg-title">dryRun</div>
         <div class="api-arg-type">boolean</div>
-        <div class="api-arg-desc">If `dryRun` is true, the operation will only check if it is possible to create a creep.</div>
+        <div class="api-arg-desc">If <code>dryRun</code> is true, the operation will only check if it is possible to create a creep.</div>
     </li>
     <li>
             <div class="api-arg-title">directions</div>

--- a/source/auth-tokens.md
+++ b/source/auth-tokens.md
@@ -43,7 +43,7 @@ Three HTTP header are set for informational purposes which you can use to handle
 | Header Name | Description |
 |-|-|
 | `X-RateLimit-Limit` | The maximum number of requests you're permitted to make per limit window. |
-| <nobr>`X-RateLimit-Remaining`</nobr> | The number of requests remaining in the current rate limit window. |
+| <nobr><code>X-RateLimit-Remaining</code></nobr> | The number of requests remaining in the current rate limit window. |
 | `X-RateLimit-Reset` | The time at which the current rate limit window resets in UTC epoch seconds. |
 
 ```

--- a/source/invaders.md
+++ b/source/invaders.md
@@ -37,18 +37,18 @@ There are two sizes of invader creeps:
 </tr>
 <tr>
 <td style="text-align: left;">Melee</td>
-<td style="text-align: center;">![](img/smallMelee.png)</td>
-<td style="text-align: center;">![](img/bigMelee.png)</td>
+<td style="text-align: center;"><img src="img/smallMelee.png" alt=""></td>
+<td style="text-align: center;"><img src="img/bigMelee.png" alt=""></td>
 </tr>
 <tr>
 <td style="text-align: left;">Ranged</td>
-<td style="text-align: center;">![](img/smallRanged.png)</td>
-<td style="text-align: center;">![](img/bigRanged.png)</td>
+<td style="text-align: center;"><img src="img/smallRanged.png" alt=""></td>
+<td style="text-align: center;"><img src="img/bigRanged.png" alt=""></td>
 </tr>
 <tr>
 <td style="text-align: left;">Healer</td>
-<td style="text-align: center;">![](img/smallHealer.png)</td>
-<td style="text-align: center;">![](img/bigHealer.png)</td>
+<td style="text-align: center;"><img src="img/smallHealer.png" alt=""></td>
+<td style="text-align: center;"><img src="img/bigHealer.png" alt=""></td>
 </tr>
 </tbody>
 </table>

--- a/source/ptr.md
+++ b/source/ptr.md
@@ -10,9 +10,9 @@ The Public Test Realm is a stand-alone game server with its own world data, play
 
 <div style="text-align: center">
 
-<p><strong style="font-size: 20px; background: #eee; padding: 10px 40px;">[ENTER](https://screeps.com/ptr/)</strong></p>
+<p><strong style="font-size: 20px; background: #eee; padding: 10px 40px;"><a href="https://screeps.com/ptr/" target="_blank" rel="external">ENTER</a></strong></p>
 
-<p>[API Reference](http://docs-ptr.screeps.com/api/)</p> 
+<p><a href="http://docs-ptr.screeps.com/api/" target="_blank" rel="external">API Reference</a></p>
 </div>
 
 ---

--- a/source/resources.md
+++ b/source/resources.md
@@ -157,29 +157,29 @@ Boosting one body part takes 30 mineral compound units and 20 energy units. One 
 <th colspan="5" align="center">Base compounds</th>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/OH.png)hydroxide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/H.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/OH.png" alt="">hydroxide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/H.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/O.png" alt=""></td>
 <td>20</td>
 <td>—</td>
 <td>—</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/ZK.png)zynthium keanite</td>
-<td>![](//static.screeps.com/upload/mineral-icons/Z.png) + ![](//static.screeps.com/upload/mineral-icons/K.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZK.png" alt="">zynthium keanite</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/Z.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/K.png" alt=""></td>
 <td>5</td>
 <td>—</td>
 <td>—</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/UL.png)utrium lemergite</td>
-<td>![](//static.screeps.com/upload/mineral-icons/U.png) + ![](//static.screeps.com/upload/mineral-icons/L.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UL.png" alt="">utrium lemergite</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/U.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/L.png" alt=""></td>
 <td>5</td>
 <td>—</td>
 <td>—</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/G.png)ghodium</td>
-<td>![](//static.screeps.com/upload/mineral-icons/ZK.png) + ![](//static.screeps.com/upload/mineral-icons/UL.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/G.png" alt="">ghodium</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZK.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/UL.png" alt=""></td>
 <td>5</td>
 <td>—</td>
 <td>—</td>
@@ -188,219 +188,219 @@ Boosting one body part takes 30 mineral compound units and 20 energy units. One 
 <th colspan="5" align="center">Tier 1 compounds</th>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/UH.png)utrium hydride</td>
-<td>![](//static.screeps.com/upload/mineral-icons/U.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UH.png" alt="">utrium hydride</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/U.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/H.png" alt=""></td>
 <td>10</td>
-<td>`ATTACK`</td>
-<td>+100% `attack` effectiveness</td>
+<td><code>ATTACK</code></td>
+<td>+100% <code>attack</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/UO.png)utrium oxide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/U.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UO.png" alt="">utrium oxide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/U.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/O.png" alt=""></td>
 <td>10</td>
-<td>`WORK`</td>
-<td>+200% `harvest` effectiveness</td>
+<td><code>WORK</code></td>
+<td>+200% <code>harvest</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/KH.png)keanium hydride</td>
-<td>![](//static.screeps.com/upload/mineral-icons/K.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KH.png" alt="">keanium hydride</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/K.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/H.png" alt=""></td>
 <td>10</td>
-<td>`CARRY`</td>
+<td><code>CARRY</code></td>
 <td>+50 capacity</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/KO.png)keanium oxide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/K.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KO.png" alt="">keanium oxide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/K.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/O.png" alt=""></td>
 <td>10</td>
-<td>`RANGED_ATTACK`</td>
-<td>+100% `rangedAttack` and `rangedMassAttack` effectiveness</td>
+<td><code>RANGED_ATTACK</code></td>
+<td>+100% <code>rangedAttack</code> and <code>rangedMassAttack</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/LH.png)lemergium hydride</td>
-<td>![](//static.screeps.com/upload/mineral-icons/L.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LH.png" alt="">lemergium hydride</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/L.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/H.png" alt=""></td>
 <td>15</td>
-<td>`WORK`</td>
-<td>+50% `repair` and `build` effectiveness without increasing the energy cost</td>
+<td><code>WORK</code></td>
+<td>+50% <code>repair</code> and <code>build</code> effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/LO.png)lemergium oxide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/L.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LO.png" alt="">lemergium oxide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/L.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/O.png" alt=""></td>
 <td>10</td>
-<td>`HEAL`</td>
-<td>+100% `heal` and `rangedHeal` effectiveness</td>
+<td><code>HEAL</code></td>
+<td>+100% <code>heal</code> and <code>rangedHeal</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/ZH.png)zynthium hydride</td>
-<td>![](//static.screeps.com/upload/mineral-icons/Z.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZH.png" alt="">zynthium hydride</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/Z.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/H.png" alt=""></td>
 <td>20</td>
-<td>`WORK`</td>
-<td>+100% `dismantle` effectiveness</td>
+<td><code>WORK</code></td>
+<td>+100% <code>dismantle</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/ZO.png)zynthium oxide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/Z.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZO.png" alt="">zynthium oxide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/Z.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/O.png" alt=""></td>
 <td>10</td>
-<td>`MOVE`</td>
+<td><code>MOVE</code></td>
 <td>+100% fatigue decrease speed</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/GH.png)ghodium hydride</td>
-<td>![](//static.screeps.com/upload/mineral-icons/G.png) + ![](//static.screeps.com/upload/mineral-icons/H.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GH.png" alt="">ghodium hydride</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/G.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/H.png" alt=""></td>
 <td>10</td>
-<td>`WORK`</td>
-<td>+50% `upgradeController` effectiveness without increasing the energy cost</td>
+<td><code>WORK</code></td>
+<td>+50% <code>upgradeController</code> effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/GO.png)ghodium oxide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/G.png) + ![](//static.screeps.com/upload/mineral-icons/O.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GO.png" alt="">ghodium oxide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/G.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/O.png" alt=""></td>
 <td>10</td>
-<td>`TOUGH`</td>
+<td><code>TOUGH</code></td>
 <td>-30% damage taken</td>
 </tr>
 <tr class=minerals__divider>
 <th colspan="5" align="center">Tier 2 compounds</th>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/UH2O.png)utrium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/UH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UH2O.png" alt="">utrium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UH.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>5</td>
-<td>`ATTACK`</td>
-<td>+200% `attack` effectiveness</td>
+<td><code>ATTACK</code></td>
+<td>+200% <code>attack</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/UHO2.png)utrium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/UO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UHO2.png" alt="">utrium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UO.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>5</td>
-<td>`WORK`</td>
-<td>+400% `harvest` effectiveness</td>
+<td><code>WORK</code></td>
+<td>+400% <code>harvest</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/KH2O.png)keanium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/KH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KH2O.png" alt="">keanium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KH.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>5</td>
-<td>`CARRY`</td>
+<td><code>CARRY</code></td>
 <td>+100 capacity</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/KHO2.png)keanium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/KO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KHO2.png" alt="">keanium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KO.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>5</td>
-<td>`RANGED_ATTACK`</td>
-<td>+200% `rangedAttack` and `rangedMassAttack` effectiveness</td>
+<td><code>RANGED_ATTACK</code></td>
+<td>+200% <code>rangedAttack</code> and <code>rangedMassAttack</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/LH2O.png)lemergium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/LH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LH2O.png" alt="">lemergium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LH.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>10</td>
-<td>`WORK`</td>
-<td>+80% `repair` and `build` effectiveness without increasing the energy cost</td>
+<td><code>WORK</code></td>
+<td>+80% <code>repair</code> and <code>build</code> effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/LHO2.png)lemergium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/LO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LHO2.png" alt="">lemergium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LO.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>5</td>
-<td>`HEAL`</td>
-<td>+200% `heal` and `rangedHeal` effectiveness</td>
+<td><code>HEAL</code></td>
+<td>+200% <code>heal</code> and <code>rangedHeal</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/ZH2O.png)zynthium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/ZH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZH2O.png" alt="">zynthium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZH.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>40</td>
-<td>`WORK`</td>
-<td>+200% `dismantle` effectiveness</td>
+<td><code>WORK</code></td>
+<td>+200% <code>dismantle</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/ZHO2.png)zynthium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/ZO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZHO2.png" alt="">zynthium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZO.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>5</td>
-<td>`MOVE`</td>
+<td><code>MOVE</code></td>
 <td>+200% fatigue decrease speed</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/GH2O.png)ghodium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/GH.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GH2O.png" alt="">ghodium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GH.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>15</td>
-<td>`WORK`</td>
-<td>+80% `upgradeController` effectiveness without increasing the energy cost</td>
+<td><code>WORK</code></td>
+<td>+80% <code>upgradeController</code> effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/GHO2.png)ghodium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/GO.png) + ![](//static.screeps.com/upload/mineral-icons/OH.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GHO2.png" alt="">ghodium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GO.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/OH.png" alt=""></td>
 <td>30</td>
-<td>`TOUGH`</td>
+<td><code>TOUGH</code></td>
 <td>-50% damage taken</td>
 </tr>
 <tr class=minerals__divider>
 <th colspan="5" align="center">Tier 3 compounds</th>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XUH2O.png)catalyzed utrium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/UH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XUH2O.png" alt="">catalyzed utrium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UH2O.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>60</td>
-<td>`ATTACK`</td>
-<td>+300% `attack` effectiveness</td>
+<td><code>ATTACK</code></td>
+<td>+300% <code>attack</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XUHO2.png)catalyzed utrium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/UHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XUHO2.png" alt="">catalyzed utrium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/UHO2.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>60</td>
-<td>`WORK`</td>
-<td>+600% `harvest` effectiveness</td>
+<td><code>WORK</code></td>
+<td>+600% <code>harvest</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XKH2O.png)catalyzed keanium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/KH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XKH2O.png" alt="">catalyzed keanium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KH2O.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>60</td>
-<td>`CARRY`</td>
+<td><code>CARRY</code></td>
 <td>+150 capacity</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XKHO2.png)catalyzed keanium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/KHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XKHO2.png" alt="">catalyzed keanium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/KHO2.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>60</td>
-<td>`RANGED_ATTACK`</td>
-<td>+300% `rangedAttack` and `rangedMassAttack` effectiveness</td>
+<td><code>RANGED_ATTACK</code></td>
+<td>+300% <code>rangedAttack</code> and <code>rangedMassAttack</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XLH2O.png)catalyzed lemergium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/LH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XLH2O.png" alt="">catalyzed lemergium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LH2O.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>65</td>
-<td>`WORK`</td>
-<td>+100% `repair` and `build` effectiveness without increasing the energy cost</td>
+<td><code>WORK</code></td>
+<td>+100% <code>repair</code> and <code>build</code> effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XLHO2.png)catalyzed lemergium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/LHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XLHO2.png" alt="">catalyzed lemergium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/LHO2.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>60</td>
-<td>`HEAL`</td>
-<td>+300% `heal` and `rangedHeal` effectiveness</td>
+<td><code>HEAL</code></td>
+<td>+300% <code>heal</code> and <code>rangedHeal</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XZH2O.png)catalyzed zynthium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/ZH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XZH2O.png" alt="">catalyzed zynthium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZH2O.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>160</td>
-<td>`WORK`</td>
-<td>+300% `dismantle` effectiveness</td>
+<td><code>WORK</code></td>
+<td>+300% <code>dismantle</code> effectiveness</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XZHO2.png)catalyzed zynthium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/ZHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XZHO2.png" alt="">catalyzed zynthium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/ZHO2.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>60</td>
-<td>`MOVE`</td>
+<td><code>MOVE</code></td>
 <td>+300% fatigue decrease speed</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XGH2O.png)catalyzed ghodium acid</td>
-<td>![](//static.screeps.com/upload/mineral-icons/GH2O.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XGH2O.png" alt="">catalyzed ghodium acid</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GH2O.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>80</td>
-<td>`WORK`</td>
-<td>+100% `upgradeController` effectiveness without increasing the energy cost</td>
+<td><code>WORK</code></td>
+<td>+100% <code>upgradeController</code> effectiveness without increasing the energy cost</td>
 </tr>
 <tr>
-<td>![](//static.screeps.com/upload/mineral-icons/XGHO2.png)catalyzed ghodium alkalide</td>
-<td>![](//static.screeps.com/upload/mineral-icons/GHO2.png) + ![](//static.screeps.com/upload/mineral-icons/X.png)</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/XGHO2.png" alt="">catalyzed ghodium alkalide</td>
+<td><img src="//static.screeps.com/upload/mineral-icons/GHO2.png" alt=""> + <img src="//static.screeps.com/upload/mineral-icons/X.png" alt=""></td>
 <td>150</td>
-<td>`TOUGH`</td>
+<td><code>TOUGH</code></td>
 <td>-70% damage taken</td>
 </tr>
 </tbody>
@@ -447,7 +447,7 @@ They also can be used to store resources in a "compressed" form.
 <i class="fa fa-plus-square"></i>
 <span>Compressing commodities</span>
 <em>(click to expand)</em>
-![](img/commodities1.png)
+<img src="img/commodities1.png" alt="">
 </div>
 
 <div class="collapsible-table__content"> 
@@ -456,14 +456,14 @@ They also can be used to store resources in a "compressed" form.
 <tr class=commodities__head>
 <th>Product</th><th>Factory</th><th>Components</th><th>Cooldown</th>
 </tr> 
-<tr><td>{% resource 'Utrium bar' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/U.png)Utrium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
-<tr><td>{% resource "Lemergium bar" %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/L.png)Lemergium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
-<tr><td>{% resource 'Zynthium bar' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/Z.png)Zynthium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
-<tr><td>{% resource 'Keanium bar' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/K.png)Keanium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
-<tr><td>{% resource 'Ghodium melt' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/G.png)Ghodium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
-<tr><td>{% resource 'Oxidant' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/O.png)Oxygen&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
-<tr><td>{% resource 'Reductant' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/H.png)Hydrogen&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
-<tr><td>{% resource 'Purifier' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td>![](//static.screeps.com/upload/mineral-icons/X.png)Catalyst&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource 'Utrium bar' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/U.png" alt="">Utrium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource "Lemergium bar" %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/L.png" alt="">Lemergium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource 'Zynthium bar' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/Z.png" alt="">Zynthium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource 'Keanium bar' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/K.png" alt="">Keanium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource 'Ghodium melt' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/G.png" alt="">Ghodium&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource 'Oxidant' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/O.png" alt="">Oxygen&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource 'Reductant' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/H.png" alt="">Hydrogen&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+<tr><td>{% resource 'Purifier' %}&nbsp;&times;&nbsp;<em>100</em></td><td>Any level</td><td><img src="//static.screeps.com/upload/mineral-icons/X.png" alt="">Catalyst&nbsp;&times;&nbsp;<em>500</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
 <tr><td>{% resource 'Battery' %}&nbsp;&times;&nbsp;<em>50</em></td><td>Any level</td><td>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>600</em></td><td>10&nbsp;ticks</td></tr>
 </tbody>
 </table>
@@ -479,20 +479,20 @@ They also can be used to store resources in a "compressed" form.
  <i class="fa fa-plus-square"></i>
  <span>Decompressing commodities</span>
  <em>(click to expand)</em>
- ![](img/commodities2.png)
+ <img src="img/commodities2.png" alt="">
  </div>
  
  <div class="collapsible-table__content">
  <table class="commodities">
  <tr class="commodities__head"><th>Product</th><th>Factory</th><th>Components</th><th>Cooldown</th></tr> 
- <tr><td>![](//static.screeps.com/upload/mineral-icons/U.png)Utrium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Utrium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
- <tr><td>![](//static.screeps.com/upload/mineral-icons/L.png)Lemergium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Lemergium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
- <tr><td>![](//static.screeps.com/upload/mineral-icons/Z.png)Zynthium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Zynthium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
- <tr><td>![](//static.screeps.com/upload/mineral-icons/K.png)Keanium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Keanium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
- <tr><td>![](//static.screeps.com/upload/mineral-icons/G.png)Ghodium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Ghodium melt' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
- <tr><td>![](//static.screeps.com/upload/mineral-icons/O.png)Oxygen&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Oxidant' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
- <tr><td>![](//static.screeps.com/upload/mineral-icons/H.png)Hydrogen&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Reductant' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
- <tr><td>![](//static.screeps.com/upload/mineral-icons/X.png)Catalyst&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Purifier' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/U.png" alt="">Utrium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Utrium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/L.png" alt="">Lemergium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Lemergium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/Z.png" alt="">Zynthium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Zynthium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/K.png" alt="">Keanium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Keanium bar' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/G.png" alt="">Ghodium&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Ghodium melt' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/O.png" alt="">Oxygen&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Oxidant' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/H.png" alt="">Hydrogen&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Reductant' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
+ <tr><td><img src="//static.screeps.com/upload/mineral-icons/X.png" alt="">Catalyst&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Purifier' %}&nbsp;&times;&nbsp;<em>100</em><br>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>200</em></td><td>20&nbsp;ticks</td></tr>
  <tr><td>{% resource 'Energy' %}&nbsp;&times;&nbsp;<em>500</em></td><td>Any level</td><td>{% resource 'Battery' %}&nbsp;&times;&nbsp;<em>50</em></td><td>10&nbsp;ticks</td></tr>
  </table> 
 
@@ -507,7 +507,7 @@ They also can be used to store resources in a "compressed" form.
 <i class="fa fa-plus-square"></i>
 <span>Basic regional commodities</span>
 <em>(click to expand)</em>
-![](img/commodities3.png)
+<img src="img/commodities3.png" alt="">
 </div>
 
 <div class="collapsible-table__content">
@@ -543,7 +543,7 @@ These commodities have the most lucrative prices on the market.
 <i class="fa fa-plus-square"></i>
 <span>Common higher commodities</span>
 <em>(click to expand)</em>
-![](img/commodities4.png)
+<img src="img/commodities4.png" alt="">
 </div>
 
 <div class="collapsible-table__content">
@@ -561,7 +561,7 @@ These commodities have the most lucrative prices on the market.
 <i class="fa fa-plus-square"></i>
 <span>Mechanical chain</span>
 <em>(click to expand)</em>
-![](img/commodities5.png)
+<img src="img/commodities5.png" alt="">
 </div>
 
 <div class="collapsible-table__content">
@@ -581,7 +581,7 @@ These commodities have the most lucrative prices on the market.
 <i class="fa fa-plus-square"></i>
 <span>Biological chain</span>
 <em>(click to expand)</em>
-![](img/commodities6.png)
+<img src="img/commodities6.png" alt="">
 </div>
 
 <div class="collapsible-table__content">
@@ -601,7 +601,7 @@ These commodities have the most lucrative prices on the market.
 <i class="fa fa-plus-square"></i>
 <span>Electronical chain</span>
 <em>(click to expand)</em>
-![](img/commodities7.png)
+<img src="img/commodities7.png" alt="">
 </div>
 
 <div class="collapsible-table__content">
@@ -621,7 +621,7 @@ These commodities have the most lucrative prices on the market.
 <i class="fa fa-plus-square"></i>
 <span>Mystical chain</span>
 <em>(click to expand)</em>
-![](img/commodities8.png)
+<img src="img/commodities8.png" alt="">
 </div>
 
 <div class="collapsible-table__content">


### PR DESCRIPTION
## What changed

Replace every Markdown image, link, and code span nested inside paired HTML elements with equivalent HTML. This covers the invader, mineral, commodity, event-log, reaction, and parameter tables plus the PTR callout and inline HTML wrappers.

Hexo `{% resource %}` tags and ordinary Markdown outside HTML are deliberately unchanged.

## Why

Markdown parsing inside raw HTML blocks is renderer-specific. The current custom renderer expands it, but CommonMark-compatible consumers treat it as literal text. Making each HTML block self-contained preserves the layout while making the source portable.

## Validation

- Generated both docs and API output with the repository's Node 10 build environment
- Compared every affected generated page to the pre-change output; content is unchanged apart from generated timestamps and source whitespace
- Scanned all docs and API Markdown files; no Markdown images, links, or code spans remain inside paired HTML elements
- `git diff --check`