### PR TITLE
Close Deposit cooldown table cell

### DIFF
--- a/api/source/Deposit.md
+++ b/api/source/Deposit.md
@@ -11,7 +11,7 @@ Learn more about deposits from [this article](/resources.html).
     <tbody>
     <tr>
         <td><strong>Cooldown</strong></td> 
-        <td>`0.001 * totalHarvested ^ 1.2`<td>
+        <td>`0.001 * totalHarvested ^ 1.2`</td>
     </tr>
     <tr>
         <td><strong>Decay</strong></td>


### PR DESCRIPTION
## What changed

Replace the second opening `<td>` on the Deposit cooldown row with the missing closing `</td>`.

## Why

The source row contained malformed HTML. Browsers repair it heuristically, but HTML consumers should not have to infer the intended cell boundary.

## Validation

- Generated the API reference with the repository's Node 10 build environment
- Parsed the generated Deposit table and verified it contains two rows and four cells
- `git diff --check`